### PR TITLE
Clean Satisfactory dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ Run the tool with:
 ```bash
 python3 satisfactory_flow_gui.py
 ```
+
+## Data files
+
+The `data/` directory contains JSON files generated from the [Official Satisfactory Wiki](https://satisfactory.wiki.gg) templates. Only the fields relevant to this tool are kept and logistic supports are omitted:
+
+- `items.json` – definitions for all items
+- `buildings.json` – only manufacturing and extraction buildings with power usage, Somersloop slots, and `inputs`/`outputs` port counts
+- `recipes.json` – all recipes including alternate recipes
+- `belts_pipes.json` – conveyor belts and pipelines with throughput (no lifts or pumps)
+- `power_plants.json` – buildings that generate power
+
+Run `python3 scripts/update_data.py` to refresh these files from the wiki.

--- a/data/belts_pipes.json
+++ b/data/belts_pipes.json
@@ -1,0 +1,34 @@
+{
+  "Desc_ConveyorBeltMk1_C": {
+    "name": "Conveyor Belt Mk.1",
+    "throughput": 60
+  },
+  "Desc_Pipeline_C": {
+    "name": "Pipeline Mk.1",
+    "throughput": 300
+  },
+  "Desc_ConveyorBeltMk5_C": {
+    "name": "Conveyor Belt Mk.5",
+    "throughput": 780
+  },
+  "Desc_ConveyorBeltMk6_C": {
+    "name": "Conveyor Belt Mk.6",
+    "throughput": 1200
+  },
+  "Desc_PipelineMK2_C": {
+    "name": "Pipeline Mk.2",
+    "throughput": 600
+  },
+  "Desc_ConveyorBeltMk4_C": {
+    "name": "Conveyor Belt Mk.4",
+    "throughput": 480
+  },
+  "Desc_ConveyorBeltMk3_C": {
+    "name": "Conveyor Belt Mk.3",
+    "throughput": 270
+  },
+  "Desc_ConveyorBeltMk2_C": {
+    "name": "Conveyor Belt Mk.2",
+    "throughput": 120
+  }
+}

--- a/data/buildings.json
+++ b/data/buildings.json
@@ -1,0 +1,148 @@
+{
+  "Desc_WaterPump_C": {
+    "name": "Water Extractor",
+    "powerUsage": 20,
+    "somersloopSlots": 0,
+    "overclockable": true,
+    "inputs": 0,
+    "outputs": 1
+  },
+  "Desc_QuantumEncoder_C": {
+    "name": "Quantum Encoder",
+    "powerUsage": 0,
+    "somersloopSlots": 4,
+    "overclockable": true,
+    "inputs": 4,
+    "outputs": 2,
+    "minPower": 0,
+    "maxPower": 2000
+  },
+  "Desc_Converter_C": {
+    "name": "Converter",
+    "powerUsage": 0,
+    "somersloopSlots": 2,
+    "overclockable": true,
+    "inputs": 2,
+    "outputs": 2,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Desc_OilPump_C": {
+    "name": "Oil Extractor",
+    "powerUsage": 40,
+    "somersloopSlots": 0,
+    "overclockable": true,
+    "inputs": 0,
+    "outputs": 1
+  },
+  "Desc_OilRefinery_C": {
+    "name": "Refinery",
+    "powerUsage": 30,
+    "somersloopSlots": 2,
+    "overclockable": true,
+    "inputs": 2,
+    "outputs": 2
+  },
+  "Desc_FoundryMk1_C": {
+    "name": "Foundry",
+    "powerUsage": 16,
+    "somersloopSlots": 2,
+    "overclockable": true,
+    "inputs": 2,
+    "outputs": 1
+  },
+  "Desc_Packager_C": {
+    "name": "Packager",
+    "powerUsage": 10,
+    "somersloopSlots": 0,
+    "overclockable": true,
+    "inputs": 2,
+    "outputs": 2
+  },
+  "Desc_MinerMk2_C": {
+    "name": "Miner Mk.2",
+    "powerUsage": 15,
+    "somersloopSlots": 0,
+    "overclockable": true,
+    "inputs": 0,
+    "outputs": 1
+  },
+  "Desc_ManufacturerMk1_C": {
+    "name": "Manufacturer",
+    "powerUsage": 55,
+    "somersloopSlots": 4,
+    "overclockable": true,
+    "inputs": 4,
+    "outputs": 1,
+    "minPower": 0,
+    "maxPower": 1500
+  },
+  "Desc_AssemblerMk1_C": {
+    "name": "Assembler",
+    "powerUsage": 15,
+    "somersloopSlots": 2,
+    "overclockable": true,
+    "inputs": 2,
+    "outputs": 1
+  },
+  "Desc_HadronCollider_C": {
+    "name": "Particle Accelerator",
+    "powerUsage": 0,
+    "somersloopSlots": 4,
+    "overclockable": true,
+    "inputs": 3,
+    "outputs": 1,
+    "minPower": 250,
+    "maxPower": 1500
+  },
+  "Desc_Blender_C": {
+    "name": "Blender",
+    "powerUsage": 75,
+    "somersloopSlots": 4,
+    "overclockable": true,
+    "inputs": 4,
+    "outputs": 2,
+    "minPower": 500,
+    "maxPower": 1500
+  },
+  "Desc_FrackingSmasher_C": {
+    "name": "Resource Well Pressurizer",
+    "powerUsage": 150,
+    "somersloopSlots": 0,
+    "overclockable": true,
+    "inputs": 0,
+    "outputs": 1
+  },
+  "Desc_MinerMk3_C": {
+    "name": "Miner Mk.3",
+    "powerUsage": 45,
+    "somersloopSlots": 0,
+    "overclockable": true,
+    "inputs": 0,
+    "outputs": 1
+  },
+  "Desc_MinerMk1_C": {
+    "name": "Miner Mk.1",
+    "powerUsage": 5,
+    "somersloopSlots": 0,
+    "overclockable": true,
+    "inputs": 0,
+    "outputs": 1
+  },
+  "Desc_ConstructorMk1_C": {
+    "name": "Constructor",
+    "powerUsage": 4,
+    "somersloopSlots": 1,
+    "overclockable": true,
+    "inputs": 1,
+    "outputs": 1
+  },
+  "Desc_SmelterMk1_C": {
+    "name": "Smelter",
+    "powerUsage": 4,
+    "somersloopSlots": 1,
+    "overclockable": true,
+    "inputs": 1,
+    "outputs": 1
+  }
+}

--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,1154 @@
+{
+  "Desc_AluminumIngot_C": {
+    "name": "Aluminum Ingot",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_HazmatFilter_C": {
+    "name": "Iodine-Infused Filter",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_IronPlate_C": {
+    "name": "Iron Plate",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_IronRod_C": {
+    "name": "Iron Rod",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_IronIngot_C": {
+    "name": "Iron Ingot",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Cable_C": {
+    "name": "Cable",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_IronPlateReinforced_C": {
+    "name": "Reinforced Iron Plate",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Wire_C": {
+    "name": "Wire",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Cement_C": {
+    "name": "Concrete",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Rotor_C": {
+    "name": "Rotor",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_CompactedCoal_C": {
+    "name": "Compacted Coal",
+    "stackSize": 100,
+    "energy": 630,
+    "form": "solid"
+  },
+  "Desc_LiquidFuel_C": {
+    "name": "Fuel",
+    "stackSize": 50000,
+    "energy": 750,
+    "form": "liquid"
+  },
+  "Desc_RocketFuel_C": {
+    "name": "Rocket Fuel",
+    "stackSize": 50000,
+    "energy": 3600,
+    "form": "gas"
+  },
+  "Desc_CopperSheet_C": {
+    "name": "Copper Sheet",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_ModularFrame_C": {
+    "name": "Modular Frame",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_IronScrew_C": {
+    "name": "Screws",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_NitricAcid_C": {
+    "name": "Nitric Acid",
+    "stackSize": 50000,
+    "energy": 0,
+    "form": "liquid"
+  },
+  "Desc_LiquidTurboFuel_C": {
+    "name": "Turbofuel",
+    "stackSize": 50000,
+    "energy": 2000,
+    "form": "liquid"
+  },
+  "Desc_GasTank_C": {
+    "name": "Empty Fluid Tank",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PackagedRocketFuel_C": {
+    "name": "Packaged Rocket Fuel",
+    "stackSize": 100,
+    "energy": 7200,
+    "form": "solid"
+  },
+  "Desc_CrystalOscillator_C": {
+    "name": "Crystal Oscillator",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Motor_C": {
+    "name": "Motor",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_TurboFuel_C": {
+    "name": "Packaged Turbofuel",
+    "stackSize": 100,
+    "energy": 2000,
+    "form": "solid"
+  },
+  "Desc_DarkMatter_C": {
+    "name": "Dark Matter Crystal",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_IonizedFuel_C": {
+    "name": "Ionized Fuel",
+    "stackSize": 50000,
+    "energy": 5000,
+    "form": "gas"
+  },
+  "Desc_ComputerSuper_C": {
+    "name": "Supercomputer",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_CoolingSystem_C": {
+    "name": "Cooling System",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_FicsiteMesh_C": {
+    "name": "Ficsite Trigon",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_MotorLightweight_C": {
+    "name": "Turbo Motor",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_TimeCrystal_C": {
+    "name": "Time Crystal",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_DarkEnergy_C": {
+    "name": "Dark Matter Residue",
+    "stackSize": 50000,
+    "energy": 0,
+    "form": "gas"
+  },
+  "Desc_SAMIngot_C": {
+    "name": "Reanimated SAM",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_QuantumEnergy_C": {
+    "name": "Excited Photonic Matter",
+    "stackSize": 50000,
+    "energy": 0,
+    "form": "gas"
+  },
+  "Desc_Diamond_C": {
+    "name": "Diamonds",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_AluminumPlate_C": {
+    "name": "Alclad Aluminum Sheet",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_QuantumOscillator_C": {
+    "name": "Superposition Oscillator",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_TemporalProcessor_C": {
+    "name": "Neural-Quantum Processor",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpaceElevatorPart_12_C": {
+    "name": "AI Expansion Server",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpaceElevatorPart_6_C": {
+    "name": "Magnetic Field Generator",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PackagedIonizedFuel_C": {
+    "name": "Packaged Ionized Fuel",
+    "stackSize": 100,
+    "energy": 10000,
+    "form": "solid"
+  },
+  "Desc_SAMFluctuator_C": {
+    "name": "SAM Fluctuator",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SteelPipe_C": {
+    "name": "Steel Pipe",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_ModularFrameFused_C": {
+    "name": "Fused Modular Frame",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_ModularFrameLightweight_C": {
+    "name": "Radio Control Unit",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_FicsiteIngot_C": {
+    "name": "Ficsite Ingot",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpaceElevatorPart_10_C": {
+    "name": "Biochemical Sculptor",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpaceElevatorPart_7_C": {
+    "name": "Assembly Director System",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_GoldIngot_C": {
+    "name": "Caterium Ingot",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_FluidCanister_C": {
+    "name": "Empty Canister",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Fuel_C": {
+    "name": "Packaged Fuel",
+    "stackSize": 100,
+    "energy": 750,
+    "form": "solid"
+  },
+  "Desc_CircuitBoard_C": {
+    "name": "Circuit Board",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Plastic_C": {
+    "name": "Plastic",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SteelPlateReinforced_C": {
+    "name": "Encased Industrial Beam",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Rubber_C": {
+    "name": "Rubber",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SteelPlate_C": {
+    "name": "Steel Beam",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PolymerResin_C": {
+    "name": "Polymer Resin",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_HeavyOilResidue_C": {
+    "name": "Heavy Oil Residue",
+    "stackSize": 50000,
+    "energy": 400,
+    "form": "liquid"
+  },
+  "Desc_PetroleumCoke_C": {
+    "name": "Petroleum Coke",
+    "stackSize": 200,
+    "energy": 180,
+    "form": "solid"
+  },
+  "Desc_QuartzCrystal_C": {
+    "name": "Quartz Crystal",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SteelIngot_C": {
+    "name": "Steel Ingot",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpaceElevatorPart_2_C": {
+    "name": "Versatile Framework",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PackagedOil_C": {
+    "name": "Packaged Oil",
+    "stackSize": 100,
+    "energy": 320,
+    "form": "solid"
+  },
+  "Desc_PackagedOilResidue_C": {
+    "name": "Packaged Heavy Oil Residue",
+    "stackSize": 100,
+    "energy": 400,
+    "form": "solid"
+  },
+  "Desc_PackagedWater_C": {
+    "name": "Packaged Water",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_CopperIngot_C": {
+    "name": "Copper Ingot",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_AluminumScrap_C": {
+    "name": "Aluminum Scrap",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_AluminumCasing_C": {
+    "name": "Aluminum Casing",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_AluminaSolution_C": {
+    "name": "Alumina Solution",
+    "stackSize": 50000,
+    "energy": 0,
+    "form": "liquid"
+  },
+  "Desc_Silica_C": {
+    "name": "Silica",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Computer_C": {
+    "name": "Computer",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_ModularFrameHeavy_C": {
+    "name": "Heavy Modular Frame",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpaceElevatorPart_1_C": {
+    "name": "Smart Plating",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_HighSpeedConnector_C": {
+    "name": "High-Speed Connector",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpaceElevatorPart_3_C": {
+    "name": "Automated Wiring",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Stator_C": {
+    "name": "Stator",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_CircuitBoardHighSpeed_C": {
+    "name": "AI Limiter",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_HighSpeedWire_C": {
+    "name": "Quickwire",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpaceElevatorPart_4_C": {
+    "name": "Modular Engine",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpaceElevatorPart_5_C": {
+    "name": "Adaptive Control Unit",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PressureConversionCube_C": {
+    "name": "Pressure Conversion Cube",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PlutoniumCell_C": {
+    "name": "Encased Plutonium Cell",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PlutoniumPellet_C": {
+    "name": "Plutonium Pellet",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_NonFissibleUranium_C": {
+    "name": "Non-Fissile Uranium",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_NuclearWaste_C": {
+    "name": "Uranium Waste",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SulfuricAcid_C": {
+    "name": "Sulfuric Acid",
+    "stackSize": 50000,
+    "energy": 0,
+    "form": "liquid"
+  },
+  "Desc_CopperDust_C": {
+    "name": "Copper Powder",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_AluminumPlateReinforced_C": {
+    "name": "Heat Sink",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_ElectromagneticControlRod_C": {
+    "name": "Electromagnetic Control Rod",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PlutoniumWaste_C": {
+    "name": "Plutonium Waste",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpaceElevatorPart_9_C": {
+    "name": "Nuclear Pasta",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_UraniumCell_C": {
+    "name": "Encased Uranium Cell",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Battery_C": {
+    "name": "Battery",
+    "stackSize": 200,
+    "energy": 6000,
+    "form": "solid"
+  },
+  "Desc_DissolvedSilica_C": {
+    "name": "Dissolved Silica",
+    "stackSize": 50000,
+    "energy": 0,
+    "form": "liquid"
+  },
+  "Desc_SpaceElevatorPart_8_C": {
+    "name": "Thermal Propulsion Rocket",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Gunpowder_C": {
+    "name": "Black Powder",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Ficsonium_C": {
+    "name": "Ficsonium",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SingularityCell_C": {
+    "name": "Singularity Cell",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpaceElevatorPart_11_C": {
+    "name": "Ballistic Warp Drive",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Filter_C": {
+    "name": "Gas Filter",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_AlienProtein_C": {
+    "name": "Alien Protein",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Crystal_C": {
+    "name": "Blue Power Slug",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_AlienDNACapsule_C": {
+    "name": "Alien DNA Capsule",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_WAT2_C": {
+    "name": "Mercer Sphere",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Crystal_mk3_C": {
+    "name": "Purple Power Slug",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Crystal_mk2_C": {
+    "name": "Yellow Power Slug",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_GunpowderMK2_C": {
+    "name": "Smokeless Powder",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_XmasStar_C": {
+    "name": "FICSMAS Wonder Star",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_XmasBallCluster_C": {
+    "name": "FICSMAS Ornament Bundle",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_XmasBranch_C": {
+    "name": "FICSMAS Tree Branch",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_XmasWreath_C": {
+    "name": "FICSMAS Wreath",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_CandyCane_C": {
+    "name": "Candy Cane",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Snow_C": {
+    "name": "FICSMAS Actual Snow",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_XmasBow_C": {
+    "name": "FICSMAS Bow",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Gift_C": {
+    "name": "FICSMAS Gift",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_XmasBall1_C": {
+    "name": "Red FICSMAS Ornament",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_XmasBall2_C": {
+    "name": "Blue FICSMAS Ornament",
+    "stackSize": 200,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_XmasBall3_C": {
+    "name": "Copper FICSMAS Ornament",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_XmasBall4_C": {
+    "name": "Iron FICSMAS Ornament",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Rebar_Explosive_C": {
+    "name": "Explosive Rebar",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Rebar_Stunshot_C": {
+    "name": "Stun Rebar",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpikedRebar_C": {
+    "name": "Iron Rebar",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_CartridgeSmartProjectile_C": {
+    "name": "Homing Rifle Ammo",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_NobeliskCluster_C": {
+    "name": "Cluster Nobelisk",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_NobeliskExplosive_C": {
+    "name": "Nobelisk",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_NobeliskGas_C": {
+    "name": "Gas Nobelisk",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_NobeliskNuke_C": {
+    "name": "Nuke Nobelisk",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_NobeliskShockwave_C": {
+    "name": "Pulse Nobelisk",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Fireworks_Projectile_01_C": {
+    "name": "Sweet Fireworks",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Fireworks_Projectile_02_C": {
+    "name": "Fancy Fireworks",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Fireworks_Projectile_03_C": {
+    "name": "Sparkly Fireworks",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SnowballProjectile_C": {
+    "name": "Snowball",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_RebarGunProjectile_C": {
+    "name": "Rebar Gun",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EquipmentDescriptorRifle_C": {
+    "name": "Rifle",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EquipmentDescriptorHazmatSuit_C": {
+    "name": "Hazmat Suit",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EquipmentDescriptorNobeliskDetonator_C": {
+    "name": "Nobelisk Detonator",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EquipmentDescriptorShockShank_C": {
+    "name": "Xeno-Zapper",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EquipmentDescriptorObjectScanner_C": {
+    "name": "Object Scanner",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_ItemDescriptorPortableMiner_C": {
+    "name": "Portable Miner",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EquipmentDescriptorHoverPack_C": {
+    "name": "Hoverpack",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EquipmentDescriptorJetPack_C": {
+    "name": "Jetpack",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EquipmentDescriptorStunSpear_C": {
+    "name": "Xeno-Basher",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Chainsaw_C": {
+    "name": "Chainsaw",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EquipmentDescriptorJumpingStilts_C": {
+    "name": "Blade Runners",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EqDescZipLine_C": {
+    "name": "Zipline",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EquipmentDescriptorGasmask_C": {
+    "name": "Gas Mask",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "BP_EquipmentDescriptorCandyCane_C": {
+    "name": "Candy Cane Basher",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_GolfCart_C": {
+    "name": "Factory Cart™",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_GolfCartGold_C": {
+    "name": "Golden Factory Cart™",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Rebar_Spreadshot_C": {
+    "name": "Shatter Rebar",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_CartridgeChaos_C": {
+    "name": "Turbo Rifle Ammo",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_CartridgeStandard_C": {
+    "name": "Rifle Ammo",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Medkit_C": {
+    "name": "Medicinal Inhaler",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_OreIron_C": {
+    "name": "Iron Ore",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Coal_C": {
+    "name": "Coal",
+    "stackSize": 100,
+    "energy": 300,
+    "form": "solid"
+  },
+  "Desc_NitrogenGas_C": {
+    "name": "Nitrogen Gas",
+    "stackSize": 50000,
+    "energy": 0,
+    "form": "gas"
+  },
+  "Desc_Sulfur_C": {
+    "name": "Sulfur",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Water_C": {
+    "name": "Water",
+    "stackSize": 50000,
+    "energy": 0,
+    "form": "liquid"
+  },
+  "Desc_SAM_C": {
+    "name": "SAM",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_OreBauxite_C": {
+    "name": "Bauxite",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_OreGold_C": {
+    "name": "Caterium Ore",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_OreCopper_C": {
+    "name": "Copper Ore",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_RawQuartz_C": {
+    "name": "Raw Quartz",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Stone_C": {
+    "name": "Limestone",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_OreUranium_C": {
+    "name": "Uranium",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_LiquidOil_C": {
+    "name": "Crude Oil",
+    "stackSize": 50000,
+    "energy": 320,
+    "form": "liquid"
+  },
+  "Desc_Leaves_C": {
+    "name": "Leaves",
+    "stackSize": 500,
+    "energy": 15,
+    "form": "solid"
+  },
+  "Desc_Wood_C": {
+    "name": "Wood",
+    "stackSize": 200,
+    "energy": 100,
+    "form": "solid"
+  },
+  "Desc_GenericBiomass_C": {
+    "name": "Biomass",
+    "stackSize": 200,
+    "energy": 180,
+    "form": "solid"
+  },
+  "Desc_Biofuel_C": {
+    "name": "Solid Biofuel",
+    "stackSize": 200,
+    "energy": 450,
+    "form": "solid"
+  },
+  "Desc_LiquidBiofuel_C": {
+    "name": "Liquid Biofuel",
+    "stackSize": 50000,
+    "energy": 750,
+    "form": "liquid"
+  },
+  "Desc_PackagedBiofuel_C": {
+    "name": "Packaged Liquid Biofuel",
+    "stackSize": 100,
+    "energy": 750,
+    "form": "solid"
+  },
+  "Desc_PackagedAlumina_C": {
+    "name": "Packaged Alumina Solution",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PackagedNitrogenGas_C": {
+    "name": "Packaged Nitrogen Gas",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PackagedNitricAcid_C": {
+    "name": "Packaged Nitric Acid",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PackagedSulfuricAcid_C": {
+    "name": "Packaged Sulfuric Acid",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Fabric_C": {
+    "name": "Fabric",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Mycelia_C": {
+    "name": "Mycelia",
+    "stackSize": 200,
+    "energy": 20,
+    "form": "solid"
+  },
+  "Desc_HogParts_C": {
+    "name": "Hog Remains",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_SpitterParts_C": {
+    "name": "Spitter Remains",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_StingerParts_C": {
+    "name": "Stinger Remains",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_HatcherParts_C": {
+    "name": "Hatcher Remains",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_CrystalShard_C": {
+    "name": "Power Shard",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_WAT1_C": {
+    "name": "Somersloop",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_PlutoniumFuelRod_C": {
+    "name": "Plutonium Fuel Rod",
+    "stackSize": 50,
+    "energy": 1500000,
+    "form": "solid"
+  },
+  "Desc_NuclearFuelRod_C": {
+    "name": "Uranium Fuel Rod",
+    "stackSize": 50,
+    "energy": 750000,
+    "form": "solid"
+  },
+  "Desc_FicsoniumFuelRod_C": {
+    "name": "Ficsonium Fuel Rod",
+    "stackSize": 50,
+    "energy": 150000,
+    "form": "solid"
+  },
+  "Desc_Berry_C": {
+    "name": "Paleberry",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Nut_C": {
+    "name": "Beryl Nut",
+    "stackSize": 100,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Shroom_C": {
+    "name": "Bacon Agaric",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_Parachute_C": {
+    "name": "Parachute",
+    "stackSize": 1,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_AlienPowerFuel_C": {
+    "name": "Alien Power Matrix",
+    "stackSize": 50,
+    "energy": 0,
+    "form": "solid"
+  },
+  "Desc_ResourceSinkCoupon_C": {
+    "name": "FICSIT Coupon",
+    "stackSize": 500,
+    "energy": 0,
+    "form": "solid"
+  }
+}

--- a/data/power_plants.json
+++ b/data/power_plants.json
@@ -1,0 +1,140 @@
+{
+  "Desc_GeneratorCoal_C": {
+    "name": "Coal-Powered Generator",
+    "powerGenerated": 75,
+    "somersloopSlots": 0,
+    "overclockable": true,
+    "burnsFuel": [
+      {
+        "fuel": "Desc_Coal_C",
+        "supplement": "Desc_Water_C",
+        "byproduct": null,
+        "byproductAmount": 0
+      },
+      {
+        "fuel": "Desc_CompactedCoal_C",
+        "supplement": "Desc_Water_C",
+        "byproduct": null,
+        "byproductAmount": 0
+      },
+      {
+        "fuel": "Desc_PetroleumCoke_C",
+        "supplement": "Desc_Water_C",
+        "byproduct": null,
+        "byproductAmount": 0
+      }
+    ],
+    "supplementPerMinute": 45
+  },
+  "Desc_GeneratorNuclear_C": {
+    "name": "Nuclear Power Plant",
+    "powerGenerated": 2500,
+    "somersloopSlots": 0,
+    "overclockable": true,
+    "burnsFuel": [
+      {
+        "fuel": "Desc_NuclearFuelRod_C",
+        "supplement": "Desc_Water_C",
+        "byproduct": "Desc_NuclearWaste_C",
+        "byproductAmount": 50
+      },
+      {
+        "fuel": "Desc_PlutoniumFuelRod_C",
+        "supplement": "Desc_Water_C",
+        "byproduct": "Desc_PlutoniumWaste_C",
+        "byproductAmount": 10
+      },
+      {
+        "fuel": "Desc_FicsoniumFuelRod_C",
+        "supplement": "Desc_Water_C",
+        "byproduct": null,
+        "byproductAmount": 0
+      }
+    ],
+    "supplementPerMinute": 240
+  },
+  "Desc_GeneratorFuel_C": {
+    "name": "Fuel-Powered Generator",
+    "powerGenerated": 250,
+    "somersloopSlots": 0,
+    "overclockable": true,
+    "burnsFuel": [
+      {
+        "fuel": "Desc_LiquidFuel_C",
+        "supplement": null,
+        "byproduct": null,
+        "byproductAmount": 0
+      },
+      {
+        "fuel": "Desc_LiquidTurboFuel_C",
+        "supplement": null,
+        "byproduct": null,
+        "byproductAmount": 0
+      },
+      {
+        "fuel": "Desc_LiquidBiofuel_C",
+        "supplement": null,
+        "byproduct": null,
+        "byproductAmount": 0
+      },
+      {
+        "fuel": "Desc_RocketFuel_C",
+        "supplement": null,
+        "byproduct": null,
+        "byproductAmount": 0
+      },
+      {
+        "fuel": "Desc_IonizedFuel_C",
+        "supplement": null,
+        "byproduct": null,
+        "byproductAmount": 0
+      }
+    ],
+    "supplementPerMinute": 0
+  },
+  "Desc_GeneratorBiomass_Automated_C": {
+    "name": "Biomass Burner",
+    "powerGenerated": 30,
+    "somersloopSlots": 0,
+    "overclockable": true,
+    "burnsFuel": [
+      {
+        "fuel": "Desc_Leaves_C",
+        "supplement": null,
+        "byproduct": null,
+        "byproductAmount": 0
+      },
+      {
+        "fuel": "Desc_Wood_C",
+        "supplement": null,
+        "byproduct": null,
+        "byproductAmount": 0
+      },
+      {
+        "fuel": "Desc_Mycelia_C",
+        "supplement": null,
+        "byproduct": null,
+        "byproductAmount": 0
+      },
+      {
+        "fuel": "Desc_GenericBiomass_C",
+        "supplement": null,
+        "byproduct": null,
+        "byproductAmount": 0
+      },
+      {
+        "fuel": "Desc_Biofuel_C",
+        "supplement": null,
+        "byproduct": null,
+        "byproductAmount": 0
+      },
+      {
+        "fuel": "Desc_PackagedBiofuel_C",
+        "supplement": null,
+        "byproduct": null,
+        "byproductAmount": 0
+      }
+    ],
+    "supplementPerMinute": 0
+  }
+}

--- a/data/recipes.json
+++ b/data/recipes.json
@@ -1,0 +1,21278 @@
+{
+  "TempRecipe_NuclearWaste_C": {
+    "name": "Uranium Fuel Rod (burning)",
+    "duration": 300,
+    "ingredients": [
+      {
+        "item": "Desc_NuclearFuelRod_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 1200
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NuclearWaste_C",
+        "amount": 50
+      }
+    ],
+    "producedIn": [
+      "Desc_GeneratorNuclear_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "TempRecipe_PlutoniumWaste_C": {
+    "name": "Plutonium Fuel Rod (burning)",
+    "duration": 600,
+    "ingredients": [
+      {
+        "item": "Desc_PlutoniumFuelRod_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 2400
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PlutoniumWaste_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_GeneratorNuclear_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_TradingPost_C": {
+    "name": "The HUB",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TradingPost_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_WorkBench_C": {
+    "name": "Crafting Bench",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_WorkBench_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_IronPlate_C": {
+    "name": "Iron Plate",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_IronRod_C": {
+    "name": "Iron Rod",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XenoZapper_C": {
+    "name": "Xeno-Zapper",
+    "duration": 40,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EquipmentDescriptorShockShank_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_IngotIron_C": {
+    "name": "Iron Ingot",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_SmelterMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorCeilingAttachment_C": {
+    "name": "Conveyor Ceiling Mount",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorCeilingAttachment_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorPole_C": {
+    "name": "Conveyor Pole",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorPole_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorPoleWall_C": {
+    "name": "Conveyor Wall Mount",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorPoleWall_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorBeltMk1_C": {
+    "name": "Conveyor Belt Mk.1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorBeltMk1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerLine_C": {
+    "name": "Power Line",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cable_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerLine_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerPoleMk1_C": {
+    "name": "Power Pole Mk.1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Wire_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerPoleMk1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerPoleWall_C": {
+    "name": "Wall Outlet Mk.1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Wire_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerPoleWall_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_RocketFuel_Nitro_C": {
+    "name": "Nitro Rocket Fuel",
+    "duration": 2.4,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidFuel_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_NitrogenGas_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Coal_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RocketFuel_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_CompactedCoal_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_GeneratorCoal_C": {
+    "name": "Coal-Powered Generator",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 30
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GeneratorCoal_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipeSupport_C": {
+    "name": "Pipeline Support",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipelineSupport_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipeSupportWall_C": {
+    "name": "Pipeline Wall Support",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipelineSupportWall_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pipeline_C": {
+    "name": "Pipeline Mk.1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Pipeline_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipelineJunction_Cross_C": {
+    "name": "Pipeline Junction",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipelineJunction_Cross_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipelinePump_C": {
+    "name": "Pipeline Pump Mk.1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipelinePump_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipeStorageTank_C": {
+    "name": "Fluid Buffer",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipeStorageTank_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_WaterPump_C": {
+    "name": "Water Extractor",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_WaterPump_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ResourceSink_C": {
+    "name": "AWESOME Sink",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 30
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 45
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ResourceSink_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ResourceSinkShop_C": {
+    "name": "AWESOME Shop",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 200
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ResourceSinkShop_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RocketFuel_C": {
+    "name": "Rocket Fuel",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidTurboFuel_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_NitricAcid_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RocketFuel_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_CompactedCoal_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PackagedRocketFuel_C": {
+    "name": "Packaged Rocket Fuel",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_RocketFuel_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_GasTank_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PackagedRocketFuel_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UnpackageRocketFuel_C": {
+    "name": "Unpackage Rocket Fuel",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_PackagedRocketFuel_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RocketFuel_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_GasTank_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_IonizedFuel_Dark_C": {
+    "name": "Dark-Ion Fuel",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_PackagedRocketFuel_C",
+        "amount": 12
+      },
+      {
+        "item": "Desc_DarkMatter_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IonizedFuel_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_CompactedCoal_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": true,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_QuantumEncoder_C": {
+    "name": "Quantum Encoder",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_MotorLightweight_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_ComputerSuper_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_CoolingSystem_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_TimeCrystal_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_FicsiteMesh_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuantumEncoder_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DarkEnergy_C": {
+    "name": "Dark Matter Residue",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DarkEnergy_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_QuantumEnergy_C": {
+    "name": "Excited Photonic Matter",
+    "duration": 3,
+    "ingredients": [],
+    "products": [
+      {
+        "item": "Desc_QuantumEnergy_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_DarkMatter_C": {
+    "name": "Dark Matter Crystal",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_Diamond_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_DarkEnergy_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DarkMatter_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": false,
+    "minPower": 500,
+    "maxPower": 1500
+  },
+  "Recipe_SuperpositionOscillator_C": {
+    "name": "Superposition Oscillator",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_DarkMatter_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 9
+      },
+      {
+        "item": "Desc_QuantumEnergy_C",
+        "amount": 25
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuantumOscillator_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_DarkEnergy_C",
+        "amount": 25
+      }
+    ],
+    "producedIn": [
+      "Desc_QuantumEncoder_C"
+    ],
+    "alternate": false,
+    "minPower": 0,
+    "maxPower": 2000
+  },
+  "Recipe_TemporalProcessor_C": {
+    "name": "Neural-Quantum Processor",
+    "duration": 20,
+    "ingredients": [
+      {
+        "item": "Desc_TimeCrystal_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_ComputerSuper_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_FicsiteMesh_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_QuantumEnergy_C",
+        "amount": 25
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TemporalProcessor_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_DarkEnergy_C",
+        "amount": 25
+      }
+    ],
+    "producedIn": [
+      "Desc_QuantumEncoder_C"
+    ],
+    "alternate": false,
+    "minPower": 0,
+    "maxPower": 2000
+  },
+  "Recipe_SpaceElevatorPart_12_C": {
+    "name": "AI Expansion Server",
+    "duration": 15,
+    "ingredients": [
+      {
+        "item": "Desc_SpaceElevatorPart_6_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_TemporalProcessor_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_QuantumOscillator_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_QuantumEnergy_C",
+        "amount": 25
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_12_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_DarkEnergy_C",
+        "amount": 25
+      }
+    ],
+    "producedIn": [
+      "Desc_QuantumEncoder_C"
+    ],
+    "alternate": false,
+    "minPower": 0,
+    "maxPower": 2000
+  },
+  "Recipe_IonizedFuel_C": {
+    "name": "Ionized Fuel",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_RocketFuel_C",
+        "amount": 16
+      },
+      {
+        "item": "Desc_CrystalShard_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IonizedFuel_C",
+        "amount": 16
+      },
+      {
+        "item": "Desc_CompactedCoal_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PackagedIonizedFuel_C": {
+    "name": "Packaged Ionized Fuel",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_IonizedFuel_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_GasTank_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PackagedIonizedFuel_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UnpackageIonizedFuel_C": {
+    "name": "Unpackage Ionized Fuel",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_PackagedIonizedFuel_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IonizedFuel_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_GasTank_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Diamond_Turbo_C": {
+    "name": "Turbo Diamonds",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_Coal_C",
+        "amount": 30
+      },
+      {
+        "item": "Desc_TurboFuel_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Diamond_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": true,
+    "minPower": 250,
+    "maxPower": 750
+  },
+  "Recipe_SAMFluctuator_C": {
+    "name": "SAM Fluctuator",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SAMFluctuator_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Converter_C": {
+    "name": "Converter",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrameFused_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_CoolingSystem_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_SAMFluctuator_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Converter_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FicsiteMesh_C": {
+    "name": "Ficsite Trigon",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_FicsiteIngot_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FicsiteMesh_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FicsiteIngot_Iron_C": {
+    "name": "Ficsite Ingot (Iron)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 24
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FicsiteIngot_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_TimeCrystal_C": {
+    "name": "Time Crystal",
+    "duration": 10,
+    "ingredients": [
+      {
+        "item": "Desc_Diamond_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TimeCrystal_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Diamond_C": {
+    "name": "Diamonds",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_Coal_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Diamond_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": false,
+    "minPower": 250,
+    "maxPower": 750
+  },
+  "Recipe_IngotSAM_C": {
+    "name": "Reanimated SAM",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_SAM_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceElevatorPart_10_C": {
+    "name": "Biochemical Sculptor",
+    "duration": 120,
+    "ingredients": [
+      {
+        "item": "Desc_SpaceElevatorPart_7_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_FicsiteMesh_C",
+        "amount": 80
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_10_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": false,
+    "minPower": 500,
+    "maxPower": 1500
+  },
+  "Recipe_FicsiteIngot_AL_C": {
+    "name": "Ficsite Ingot (Aluminum)",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_AluminumIngot_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FicsiteIngot_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_FicsiteIngot_CAT_C": {
+    "name": "Ficsite Ingot (Caterium)",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_GoldIngot_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FicsiteIngot_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Bauxite_Caterium_C": {
+    "name": "Bauxite (Caterium)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_OreGold_C",
+        "amount": 15
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_OreBauxite_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Bauxite_Copper_C": {
+    "name": "Bauxite (Copper)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_OreCopper_C",
+        "amount": 18
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_OreBauxite_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Caterium_Copper_C": {
+    "name": "Caterium Ore (Copper)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_OreCopper_C",
+        "amount": 15
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_OreGold_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Caterium_Quartz_C": {
+    "name": "Caterium Ore (Quartz)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_RawQuartz_C",
+        "amount": 12
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_OreGold_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Coal_Iron_C": {
+    "name": "Coal (Iron)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 18
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Coal_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Coal_Limestone_C": {
+    "name": "Coal (Limestone)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Stone_C",
+        "amount": 36
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Coal_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Copper_Quartz_C": {
+    "name": "Copper Ore (Quartz)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_RawQuartz_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_OreCopper_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Copper_Sulfur_C": {
+    "name": "Copper Ore (Sulfur)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 12
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_OreCopper_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Iron_Limestone_C": {
+    "name": "Iron Ore (Limestone)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Stone_C",
+        "amount": 24
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Limestone_Sulfur_C": {
+    "name": "Limestone (Sulfur)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stone_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Nitrogen_Bauxite_C": {
+    "name": "Nitrogen Gas (Bauxite)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_OreBauxite_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NitrogenGas_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Nitrogen_Caterium_C": {
+    "name": "Nitrogen Gas (Caterium)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_OreGold_C",
+        "amount": 12
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NitrogenGas_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Quartz_Bauxite_C": {
+    "name": "Raw Quartz (Bauxite)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_OreBauxite_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RawQuartz_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Quartz_Coal_C": {
+    "name": "Raw Quartz (Coal)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Coal_C",
+        "amount": 24
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RawQuartz_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Sulfur_Coal_C": {
+    "name": "Sulfur (Coal)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Coal_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Sulfur_Iron_C": {
+    "name": "Sulfur (Iron)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 30
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Uranium_Bauxite_C": {
+    "name": "Uranium Ore (Bauxite)",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SAMIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_OreBauxite_C",
+        "amount": 48
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_OreUranium_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": false,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Alternate_Turbofuel_C": {
+    "name": "Turbofuel",
+    "duration": 16,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidFuel_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_CompactedCoal_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LiquidTurboFuel_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PackagedTurboFuel_C": {
+    "name": "Packaged Turbofuel",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidTurboFuel_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TurboFuel_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UnpackageTurboFuel_C": {
+    "name": "Unpackage Turbofuel",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_TurboFuel_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LiquidTurboFuel_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Coal_1_C": {
+    "name": "Charcoal",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_Wood_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Coal_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Coal_2_C": {
+    "name": "Biocoal",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_GenericBiomass_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Coal_C",
+        "amount": 6
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_EnrichedCoal_C": {
+    "name": "Compacted Coal",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Coal_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CompactedCoal_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CircuitBoard_C": {
+    "name": "Circuit Board",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CircuitBoard_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_OilPump_C": {
+    "name": "Oil Extractor",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 60
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_OilPump_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_OilRefinery_C": {
+    "name": "Refinery",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 30
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_OilRefinery_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Valve_C": {
+    "name": "Valve",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Valve_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_LiquidFuel_C": {
+    "name": "Fuel",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidOil_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LiquidFuel_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_PolymerResin_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PetroleumCoke_C": {
+    "name": "Petroleum Coke",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PetroleumCoke_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Plastic_C": {
+    "name": "Plastic",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidOil_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Rubber_C": {
+    "name": "Rubber",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidOil_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ResidualFuel_C": {
+    "name": "Residual Fuel",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LiquidFuel_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ResidualPlastic_C": {
+    "name": "Residual Plastic",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_PolymerResin_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ResidualRubber_C": {
+    "name": "Residual Rubber",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_PolymerResin_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Diamond_Pink_C": {
+    "name": "Pink Diamonds",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_Coal_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Diamond_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Converter_C"
+    ],
+    "alternate": true,
+    "minPower": 100,
+    "maxPower": 400
+  },
+  "Recipe_Alternate_Diamond_Petroleum_C": {
+    "name": "Petroleum Diamonds",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_PetroleumCoke_C",
+        "amount": 24
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Diamond_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": true,
+    "minPower": 250,
+    "maxPower": 750
+  },
+  "Recipe_Alternate_Diamond_OilBased_C": {
+    "name": "Oil-Based Diamonds",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidOil_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Diamond_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": true,
+    "minPower": 250,
+    "maxPower": 750
+  },
+  "Recipe_Alternate_Diamond_Cloudy_C": {
+    "name": "Cloudy Diamonds",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_Coal_C",
+        "amount": 12
+      },
+      {
+        "item": "Desc_Stone_C",
+        "amount": 24
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Diamond_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": true,
+    "minPower": 250,
+    "maxPower": 750
+  },
+  "Recipe_Alternate_DarkMatter_Trap_C": {
+    "name": "Dark Matter Trap",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_TimeCrystal_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_DarkEnergy_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DarkMatter_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": true,
+    "minPower": 500,
+    "maxPower": 1500
+  },
+  "Recipe_Alternate_DarkMatter_Crystallization_C": {
+    "name": "Dark Matter Crystallization",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_DarkEnergy_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DarkMatter_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": true,
+    "minPower": 500,
+    "maxPower": 1500
+  },
+  "Recipe_Alternate_WetConcrete_C": {
+    "name": "Wet Concrete",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_Stone_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_TurboHeavyFuel_C": {
+    "name": "Turbo Heavy Fuel",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_CompactedCoal_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LiquidTurboFuel_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_SteelRod_C": {
+    "name": "Steel Rod",
+    "duration": 5,
+    "ingredients": [
+      {
+        "item": "Desc_SteelIngot_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SmelterMk1_C": {
+    "name": "Foundry",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FoundryMk1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelBeam_C": {
+    "name": "Steel Beam",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_SteelIngot_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelPipe_C": {
+    "name": "Steel Pipe",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SteelIngot_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_IngotSteel_C": {
+    "name": "Steel Ingot",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Coal_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelIngot_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceElevatorPart_2_C": {
+    "name": "Versatile Framework",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 12
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_2_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_SteelCanister_C": {
+    "name": "Steel Canister",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SteelIngot_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Packager_C": {
+    "name": "Packager",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Packager_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FluidCanister_C": {
+    "name": "Empty Canister",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Fuel_C": {
+    "name": "Packaged Fuel",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidFuel_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Fuel_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_LiquidBiofuel_C": {
+    "name": "Liquid Biofuel",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_Biofuel_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LiquidBiofuel_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PackagedBiofuel_C": {
+    "name": "Packaged Liquid Biofuel",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidBiofuel_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PackagedBiofuel_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PackagedCrudeOil_C": {
+    "name": "Packaged Oil",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidOil_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PackagedOil_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PackagedOilResidue_C": {
+    "name": "Packaged Heavy Oil Residue",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PackagedOilResidue_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PackagedWater_C": {
+    "name": "Packaged Water",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_Water_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PackagedWater_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UnpackageBioFuel_C": {
+    "name": "Unpackage Liquid Biofuel",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_PackagedBiofuel_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LiquidBiofuel_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UnpackageFuel_C": {
+    "name": "Unpackage Fuel",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_Fuel_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LiquidFuel_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UnpackageOil_C": {
+    "name": "Unpackage Oil",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_PackagedOil_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LiquidOil_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UnpackageOilResidue_C": {
+    "name": "Unpackage Heavy Oil Residue",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_PackagedOilResidue_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UnpackageWater_C": {
+    "name": "Unpackage Water",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_PackagedWater_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Water_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_SteamedCopperSheet_C": {
+    "name": "Steamed Copper Sheet",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_RubberConcrete_C": {
+    "name": "Rubber Concrete",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_Stone_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 9
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_RecycledRubber_C": {
+    "name": "Recycled Rubber",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_LiquidFuel_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_PureQuartzCrystal_C": {
+    "name": "Pure Quartz Crystal",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_RawQuartz_C",
+        "amount": 9
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 7
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuartzCrystal_C": {
+    "name": "Quartz Crystal",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_RawQuartz_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_PureIronIngot_C": {
+    "name": "Pure Iron Ingot",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 7
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 13
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_PureCopperIngot_C": {
+    "name": "Pure Copper Ingot",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_OreCopper_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 15
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_PureCateriumIngot_C": {
+    "name": "Pure Caterium Ingot",
+    "duration": 5,
+    "ingredients": [
+      {
+        "item": "Desc_OreGold_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GoldIngot_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PureAluminumIngot_C": {
+    "name": "Pure Aluminum Ingot",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumScrap_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminumIngot_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_SmelterMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_AluminumCasing_C": {
+    "name": "Aluminum Casing",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumIngot_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_AluminumSheet_C": {
+    "name": "Alclad Aluminum Sheet",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumIngot_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_AluminaSolution_C": {
+    "name": "Alumina Solution",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_OreBauxite_C",
+        "amount": 12
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 18
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminaSolution_C",
+        "amount": 12
+      },
+      {
+        "item": "Desc_Silica_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_AluminumScrap_C": {
+    "name": "Aluminum Scrap",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_AluminaSolution_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Coal_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminumScrap_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PackagedAlumina_C": {
+    "name": "Packaged Alumina Solution",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_AluminaSolution_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PackagedAlumina_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_IngotAluminum_C": {
+    "name": "Aluminum Ingot",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumScrap_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_Silica_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminumIngot_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Silica_C": {
+    "name": "Silica",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_RawQuartz_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CrystalOscillator_C": {
+    "name": "Crystal Oscillator",
+    "duration": 120,
+    "ingredients": [
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 36
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 28
+      },
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UnpackageAlumina_C": {
+    "name": "Unpackage Alumina Solution",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_PackagedAlumina_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminaSolution_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_PolymerResin_C": {
+    "name": "Polymer Resin",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidOil_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PolymerResin_C",
+        "amount": 13
+      },
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_PlasticSmartPlating_C": {
+    "name": "Plastic Smart Plating",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_1_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_HighSpeedWiring_C": {
+    "name": "Automated Speed Wiring",
+    "duration": 32,
+    "ingredients": [
+      {
+        "item": "Desc_Stator_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 40
+      },
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_3_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_EncasedIndustrialBeam_C": {
+    "name": "Encased Industrial Beam",
+    "duration": 10,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Motor_C": {
+    "name": "Motor",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Stator_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stator_C": {
+    "name": "Stator",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stator_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_MinerMk2_C": {
+    "name": "Miner Mk.2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "BP_ItemDescriptorPortableMiner_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_MinerMk2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceElevatorPart_3_C": {
+    "name": "Automated Wiring",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_Stator_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_3_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_AILimiter_C": {
+    "name": "AI Limiter",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CircuitBoardHighSpeed_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_HeavyOilResidue_C": {
+    "name": "Heavy Oil Residue",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidOil_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_PolymerResin_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_HeavyFlexibleFrame_C": {
+    "name": "Heavy Flexible Frame",
+    "duration": 16,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 104
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ManufacturerMk1_C": {
+    "name": "Manufacturer",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ManufacturerMk1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Computer_C": {
+    "name": "Computer",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_CircuitBoard_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 16
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Computer_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ModularFrameHeavy_C": {
+    "name": "Heavy Modular Frame",
+    "duration": 30,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 120
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceElevatorPart_4_C": {
+    "name": "Modular Engine",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_SpaceElevatorPart_1_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceElevatorPart_5_C": {
+    "name": "Adaptive Control Unit",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_SpaceElevatorPart_3_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_CircuitBoard_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Computer_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_5_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_FusedWire_C": {
+    "name": "Fused Wire",
+    "duration": 20,
+    "ingredients": [
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_GoldIngot_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wire_C",
+        "amount": 30
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_FlexibleFramework_C": {
+    "name": "Flexible Framework",
+    "duration": 16,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_2_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_ElectrodeCircuitBoard_C": {
+    "name": "Electrode Circuit Board",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_PetroleumCoke_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CircuitBoard_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_ElectroAluminumScrap_C": {
+    "name": "Electrode Aluminum Scrap",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_AluminaSolution_C",
+        "amount": 12
+      },
+      {
+        "item": "Desc_PetroleumCoke_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminumScrap_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 7
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_DilutedPackagedFuel_C": {
+    "name": "Diluted Packaged Fuel",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_PackagedWater_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Fuel_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CopperRotor_C": {
+    "name": "Copper Rotor",
+    "duration": 16,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 52
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ModularFrame_C": {
+    "name": "Modular Frame",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 12
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Rotor_C": {
+    "name": "Rotor",
+    "duration": 15,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 25
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_AssemblerMk1_C": {
+    "name": "Assembler",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AssemblerMk1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CopperSheet_C": {
+    "name": "Copper Sheet",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceElevatorPart_1_C": {
+    "name": "Smart Plating",
+    "duration": 30,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CopperAlloyIngot_C": {
+    "name": "Copper Alloy Ingot",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_OreCopper_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CokeSteelIngot_C": {
+    "name": "Coke Steel Ingot",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_PetroleumCoke_C",
+        "amount": 15
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelIngot_C",
+        "amount": 20
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CoatedIronPlate_C": {
+    "name": "Coated Iron Plate",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CoatedIronCanister_C": {
+    "name": "Coated Iron Canister",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CoatedCable_C": {
+    "name": "Coated Cable",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_Wire_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Cable_C",
+        "amount": 9
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_BoltedFrame_C": {
+    "name": "Bolted Frame",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 56
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_AdheredIronPlate_C": {
+    "name": "Adhered Iron Plate",
+    "duration": 16,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_TurboPressureMotor_C": {
+    "name": "Turbo Pressure Motor",
+    "duration": 32,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_PressureConversionCube_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_PackagedNitrogenGas_C",
+        "amount": 24
+      },
+      {
+        "item": "Desc_Stator_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_MotorLightweight_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PlutoniumCell_C": {
+    "name": "Encased Plutonium Cell",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_PlutoniumPellet_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PlutoniumCell_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PressureConversionCube_C": {
+    "name": "Pressure Conversion Cube",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrameFused_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PressureConversionCube_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_NitricAcid_C": {
+    "name": "Nitric Acid",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_NitrogenGas_C",
+        "amount": 12
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NitricAcid_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_NonFissileUranium_C": {
+    "name": "Non-Fissile Uranium",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_NuclearWaste_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_Silica_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_NitricAcid_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NonFissibleUranium_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 6
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_HadronCollider_C": {
+    "name": "Particle Accelerator",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_MotorLightweight_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ComputerSuper_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ModularFrameFused_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_CoolingSystem_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 500
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HadronCollider_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CopperDust_C": {
+    "name": "Copper Powder",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 30
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CopperDust_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Plutonium_C": {
+    "name": "Plutonium Pellet",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_NonFissibleUranium_C",
+        "amount": 100
+      },
+      {
+        "item": "Desc_NuclearWaste_C",
+        "amount": 25
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PlutoniumPellet_C",
+        "amount": 30
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": false,
+    "minPower": 250,
+    "maxPower": 750
+  },
+  "Recipe_PlutoniumFuelRod_C": {
+    "name": "Plutonium Fuel Rod",
+    "duration": 240,
+    "ingredients": [
+      {
+        "item": "Desc_PlutoniumCell_C",
+        "amount": 30
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 18
+      },
+      {
+        "item": "Desc_ElectromagneticControlRod_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_AluminumPlateReinforced_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PlutoniumFuelRod_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PackagedNitricAcid_C": {
+    "name": "Packaged Nitric Acid",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_NitricAcid_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_GasTank_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PackagedNitricAcid_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceElevatorPart_9_C": {
+    "name": "Nuclear Pasta",
+    "duration": 120,
+    "ingredients": [
+      {
+        "item": "Desc_CopperDust_C",
+        "amount": 200
+      },
+      {
+        "item": "Desc_PressureConversionCube_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_9_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": false,
+    "minPower": 500,
+    "maxPower": 1500
+  },
+  "Recipe_UnpackageNitricAcid_C": {
+    "name": "Unpackage Nitric Acid",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_PackagedNitricAcid_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NitricAcid_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_GasTank_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_TurboBlendFuel_C": {
+    "name": "Turbo Blend Fuel",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_LiquidFuel_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_PetroleumCoke_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LiquidTurboFuel_C",
+        "amount": 6
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UraniumCell_C": {
+    "name": "Encased Uranium Cell",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_OreUranium_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_UraniumCell_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CoolingSystem_C": {
+    "name": "Cooling System",
+    "duration": 10,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumPlateReinforced_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_NitrogenGas_C",
+        "amount": 25
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CoolingSystem_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Blender_C": {
+    "name": "Blender",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Computer_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Motor_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Blender_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Battery_C": {
+    "name": "Battery",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 2.5
+      },
+      {
+        "item": "Desc_AluminaSolution_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Battery_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 1.5
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ComputerSuper_C": {
+    "name": "Supercomputer",
+    "duration": 32,
+    "ingredients": [
+      {
+        "item": "Desc_Computer_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_CircuitBoardHighSpeed_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 28
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ComputerSuper_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RadioControlUnit_C": {
+    "name": "Radio Control Unit",
+    "duration": 48,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 32
+      },
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Computer_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SulfuricAcid_C": {
+    "name": "Sulfuric Acid",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PackagedSulfuricAcid_C": {
+    "name": "Packaged Sulfuric Acid",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PackagedSulfuricAcid_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceElevatorPart_7_C": {
+    "name": "Assembly Director System",
+    "duration": 80,
+    "ingredients": [
+      {
+        "item": "Desc_SpaceElevatorPart_5_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_ComputerSuper_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_7_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_HighSpeedConnector_C": {
+    "name": "High-Speed Connector",
+    "duration": 16,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 56
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_CircuitBoard_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UnpackageSulfuricAcid_C": {
+    "name": "Unpackage Sulfuric Acid",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_PackagedSulfuricAcid_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_FluidCanister_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_SuperStateComputer_C": {
+    "name": "Super-State Computer",
+    "duration": 25,
+    "ingredients": [
+      {
+        "item": "Desc_Computer_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_ElectromagneticControlRod_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Battery_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 25
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ComputerSuper_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ElectromagneticControlRod_C": {
+    "name": "Electromagnetic Control Rod",
+    "duration": 30,
+    "ingredients": [
+      {
+        "item": "Desc_Stator_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_CircuitBoardHighSpeed_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ElectromagneticControlRod_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_GeneratorNuclear_C": {
+    "name": "Nuclear Power Plant",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ComputerSuper_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 100
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 200
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 250
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GeneratorNuclear_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_NuclearFuelRod_C": {
+    "name": "Uranium Fuel Rod",
+    "duration": 150,
+    "ingredients": [
+      {
+        "item": "Desc_UraniumCell_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_ElectromagneticControlRod_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NuclearFuelRod_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceElevatorPart_6_C": {
+    "name": "Magnetic Field Generator",
+    "duration": 120,
+    "ingredients": [
+      {
+        "item": "Desc_SpaceElevatorPart_2_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_ElectromagneticControlRod_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_6_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_SloppyAlumina_C": {
+    "name": "Sloppy Alumina",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_OreBauxite_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminaSolution_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_RadioControlSystem_C": {
+    "name": "Radio Control System",
+    "duration": 40,
+    "ingredients": [
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_CircuitBoard_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 60
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 30
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_PlutoniumFuelUnit_C": {
+    "name": "Plutonium Fuel Unit",
+    "duration": 120,
+    "ingredients": [
+      {
+        "item": "Desc_PlutoniumCell_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_PressureConversionCube_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PlutoniumFuelRod_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_OCSupercomputer_C": {
+    "name": "OC Supercomputer",
+    "duration": 20,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_CoolingSystem_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ComputerSuper_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_HeatSink_C": {
+    "name": "Heat Sink",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminumPlateReinforced_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FusedModularFrame_C": {
+    "name": "Fused Modular Frame",
+    "duration": 40,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_NitrogenGas_C",
+        "amount": 25
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ModularFrameFused_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FrackingExtractor_C": {
+    "name": "Resource Well Extractor",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FrackingExtractor_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FrackingSmasher_C": {
+    "name": "Resource Well Pressurizer",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_Motor_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FrackingSmasher_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_GasTank_C": {
+    "name": "Empty Fluid Tank",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumIngot_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GasTank_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PackagedNitrogen_C": {
+    "name": "Packaged Nitrogen Gas",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_NitrogenGas_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_GasTank_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PackagedNitrogenGas_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UnpackageNitrogen_C": {
+    "name": "Unpackage Nitrogen Gas",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_PackagedNitrogenGas_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NitrogenGas_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_GasTank_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Packager_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_InstantScrap_C": {
+    "name": "Instant Scrap",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_OreBauxite_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_Coal_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminumScrap_C",
+        "amount": 30
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_InstantPlutoniumCell_C": {
+    "name": "Instant Plutonium Cell",
+    "duration": 120,
+    "ingredients": [
+      {
+        "item": "Desc_NonFissibleUranium_C",
+        "amount": 150
+      },
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PlutoniumCell_C",
+        "amount": 20
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": true,
+    "minPower": 250,
+    "maxPower": 750
+  },
+  "Recipe_Alternate_HeatFusedFrame_C": {
+    "name": "Heat-Fused Frame",
+    "duration": 20,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_AluminumIngot_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_NitricAcid_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_LiquidFuel_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ModularFrameFused_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_FertileUranium_C": {
+    "name": "Fertile Uranium",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_OreUranium_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_NuclearWaste_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_NitricAcid_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NonFissibleUranium_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 8
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_ElectricMotor_C": {
+    "name": "Electric Motor",
+    "duration": 16,
+    "ingredients": [
+      {
+        "item": "Desc_ElectromagneticControlRod_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_DilutedFuel_C": {
+    "name": "Diluted Fuel",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LiquidFuel_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CoolingDevice_C": {
+    "name": "Cooling Device",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumPlateReinforced_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Motor_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_NitrogenGas_C",
+        "amount": 24
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CoolingSystem_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_ClassicBattery_C": {
+    "name": "Classic Battery",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 7
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 12
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Battery_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_AutomatedMiner_C": {
+    "name": "Automated Miner",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_ItemDescriptorPortableMiner_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_AlcladCasing_C": {
+    "name": "Alclad Casing",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumIngot_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 15
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_SteelPipe_Molded_C": {
+    "name": "Molded Steel Pipe",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SteelIngot_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_SteelPipe_Iron_C": {
+    "name": "Iron Pipe",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_SteelCastedPlate_C": {
+    "name": "Steel Cast Plate",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_SteelIngot_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_SteelBeam_Molded_C": {
+    "name": "Molded Beam",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_SteelIngot_C",
+        "amount": 24
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 16
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 9
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_SteelBeam_Aluminum_C": {
+    "name": "Aluminum Beam",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumIngot_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_AluminumRod_C": {
+    "name": "Aluminum Rod",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumIngot_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 7
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_AILimiter_Plastic_C": {
+    "name": "Plastic AI Limiter",
+    "duration": 15,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 30
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 7
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CircuitBoardHighSpeed_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Silica_Distilled_C": {
+    "name": "Distilled Silica",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_DissolvedSilica_C",
+        "amount": 12
+      },
+      {
+        "item": "Desc_Stone_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 27
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 8
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Quartz_Purified_C": {
+    "name": "Quartz Purification",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_RawQuartz_C",
+        "amount": 24
+      },
+      {
+        "item": "Desc_NitricAcid_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_DissolvedSilica_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Quartz_Fused_C": {
+    "name": "Fused Quartz Crystal",
+    "duration": 20,
+    "ingredients": [
+      {
+        "item": "Desc_RawQuartz_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_Coal_C",
+        "amount": 12
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 18
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_IronIngot_Leached_C": {
+    "name": "Leached Iron Ingot",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_IronIngot_Basic_C": {
+    "name": "Basic Iron Ingot",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Stone_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CopperIngot_Tempered_C": {
+    "name": "Tempered Copper Ingot",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_OreCopper_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_PetroleumCoke_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CopperIngot_Leached_C": {
+    "name": "Leached Copper Ingot",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_OreCopper_C",
+        "amount": 9
+      },
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 22
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CateriumIngot_Tempered_C": {
+    "name": "Tempered Caterium Ingot",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_OreGold_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_PetroleumCoke_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GoldIngot_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CateriumIngot_Leached_C": {
+    "name": "Leached Caterium Ingot",
+    "duration": 10,
+    "ingredients": [
+      {
+        "item": "Desc_OreGold_C",
+        "amount": 9
+      },
+      {
+        "item": "Desc_SulfuricAcid_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GoldIngot_C",
+        "amount": 6
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Wire_2_C": {
+    "name": "Caterium Wire",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_GoldIngot_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wire_C",
+        "amount": 8
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Wire_1_C": {
+    "name": "Iron Wire",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wire_C",
+        "amount": 9
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_UraniumCell_1_C": {
+    "name": "Infused Uranium Cell",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_OreUranium_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Silica_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 15
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_UraniumCell_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DroneStation_C": {
+    "name": "Drone Port",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DroneStation_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DroneTransport_C": {
+    "name": "Drone",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_CircuitBoardHighSpeed_C",
+        "amount": 2
+      },
+      {
+        "item": "BP_ItemDescriptorPortableMiner_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DroneTransport_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_IngotCaterium_C": {
+    "name": "Caterium Ingot",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_OreGold_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GoldIngot_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_SmelterMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_TurboMotor_1_C": {
+    "name": "Turbo Electric Motor",
+    "duration": 64,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 7
+      },
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 9
+      },
+      {
+        "item": "Desc_ElectromagneticControlRod_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 7
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_MotorLightweight_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorBeltMk5_C": {
+    "name": "Conveyor Belt Mk.5",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorBeltMk5_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorLiftMk5_C": {
+    "name": "Conveyor Lift Mk.5",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorLiftMk5_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_MinerMk3_C": {
+    "name": "Miner Mk.3",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "BP_ItemDescriptorPortableMiner_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_ComputerSuper_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_ModularFrameFused_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_MotorLightweight_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_MinerMk3_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_MotorTurbo_C": {
+    "name": "Turbo Motor",
+    "duration": 32,
+    "ingredients": [
+      {
+        "item": "Desc_CoolingSystem_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Motor_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 24
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_MotorLightweight_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceElevatorPart_8_C": {
+    "name": "Thermal Propulsion Rocket",
+    "duration": 120,
+    "ingredients": [
+      {
+        "item": "Desc_SpaceElevatorPart_4_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_MotorLightweight_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_CoolingSystem_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_ModularFrameFused_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_8_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Stator_C": {
+    "name": "Quickwire Stator",
+    "duration": 15,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 15
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stator_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Silica_C": {
+    "name": "Cheap Silica",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_RawQuartz_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Stone_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 7
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Screw_2_C": {
+    "name": "Steel Screws",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 52
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Screw_C": {
+    "name": "Cast Screws",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 20
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Rotor_C": {
+    "name": "Steel Rotor",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_EncasedIndustrialBeam_C": {
+    "name": "Encased Industrial Pipe",
+    "duration": 15,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_ReinforcedIronPlate_2_C": {
+    "name": "Stitched Iron Plate",
+    "duration": 32,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_ReinforcedIronPlate_1_C": {
+    "name": "Bolted Iron Plate",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 18
+      },
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_RadioControlUnit_1_C": {
+    "name": "Radio Connection Unit",
+    "duration": 16,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumPlateReinforced_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 12
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Quickwire_C": {
+    "name": "Fused Quickwire",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_GoldIngot_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Plastic_1_C": {
+    "name": "Recycled Plastic",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_LiquidFuel_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_NuclearFuelRod_1_C": {
+    "name": "Uranium Fuel Unit",
+    "duration": 300,
+    "ingredients": [
+      {
+        "item": "Desc_UraniumCell_C",
+        "amount": 100
+      },
+      {
+        "item": "Desc_ElectromagneticControlRod_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NuclearFuelRod_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Motor_1_C": {
+    "name": "Rigor Motor",
+    "duration": 48,
+    "ingredients": [
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Stator_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 6
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_ModularFrame_C": {
+    "name": "Steeled Frame",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_IngotSteel_2_C": {
+    "name": "Compacted Steel Ingot",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_CompactedCoal_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelIngot_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_IngotSteel_1_C": {
+    "name": "Solid Steel Ingot",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Coal_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelIngot_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_IngotIron_C": {
+    "name": "Iron Alloy Ingot",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_OreIron_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_OreCopper_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 15
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_HighSpeedConnector_C": {
+    "name": "Silicon High-Speed Connector",
+    "duration": 40,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 60
+      },
+      {
+        "item": "Desc_Silica_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_CircuitBoard_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_ModularFrameHeavy_C": {
+    "name": "Heavy Encased Frame",
+    "duration": 64,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 36
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 22
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 3
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_HeatSink_1_C": {
+    "name": "Heat Exchanger",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AluminumPlateReinforced_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Gunpowder_1_C": {
+    "name": "Fine Black Powder",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_CompactedCoal_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Gunpowder_C",
+        "amount": 6
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_ElectromagneticControlRod_1_C": {
+    "name": "Electromagnetic Connection Rod",
+    "duration": 15,
+    "ingredients": [
+      {
+        "item": "Desc_Stator_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ElectromagneticControlRod_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CrystalOscillator_C": {
+    "name": "Insulated Crystal Oscillator",
+    "duration": 32,
+    "ingredients": [
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 7
+      },
+      {
+        "item": "Desc_CircuitBoardHighSpeed_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Concrete_C": {
+    "name": "Fine Concrete",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Stone_C",
+        "amount": 12
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Computer_2_C": {
+    "name": "Crystal Computer",
+    "duration": 36,
+    "ingredients": [
+      {
+        "item": "Desc_CircuitBoard_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Computer_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Computer_1_C": {
+    "name": "Caterium Computer",
+    "duration": 16,
+    "ingredients": [
+      {
+        "item": "Desc_CircuitBoard_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 14
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Computer_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CircuitBoard_2_C": {
+    "name": "Caterium Circuit Board",
+    "duration": 48,
+    "ingredients": [
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 30
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CircuitBoard_C",
+        "amount": 7
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_CircuitBoard_1_C": {
+    "name": "Silicon Circuit Board",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 11
+      },
+      {
+        "item": "Desc_Silica_C",
+        "amount": 11
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CircuitBoard_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Cable_2_C": {
+    "name": "Quickwire Cable",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Cable_C",
+        "amount": 11
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_Cable_1_C": {
+    "name": "Insulated Cable",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Wire_C",
+        "amount": 9
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Cable_C",
+        "amount": 20
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorBeltMk6_C": {
+    "name": "Conveyor Belt Mk.6",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_FicsiteMesh_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_TimeCrystal_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorBeltMk6_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorLiftMk6_C": {
+    "name": "Conveyor Lift Mk.6",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_FicsiteMesh_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_TimeCrystal_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorLiftMk6_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ficsonium_C": {
+    "name": "Ficsonium",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_PlutoniumWaste_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_SingularityCell_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_DarkEnergy_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ficsonium_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_HadronCollider_C"
+    ],
+    "alternate": false,
+    "minPower": 500,
+    "maxPower": 1500
+  },
+  "Recipe_FicsoniumFuelRod_C": {
+    "name": "Ficsonium Fuel Rod",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_Ficsonium_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_ElectromagneticControlRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_FicsiteMesh_C",
+        "amount": 40
+      },
+      {
+        "item": "Desc_QuantumEnergy_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FicsoniumFuelRod_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_DarkEnergy_C",
+        "amount": 20
+      }
+    ],
+    "producedIn": [
+      "Desc_QuantumEncoder_C"
+    ],
+    "alternate": false,
+    "minPower": 0,
+    "maxPower": 2000
+  },
+  "Recipe_Portal_C": {
+    "name": "Main Portal",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_MotorLightweight_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_QuantumOscillator_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_SAMFluctuator_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_FicsiteMesh_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Portal_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PortalSatellite_C": {
+    "name": "Satellite Portal",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrameLightweight_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_QuantumOscillator_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SAMFluctuator_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_FicsiteMesh_C",
+        "amount": 25
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PortalSatellite_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SingularityCell_C": {
+    "name": "Singularity Cell",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_SpaceElevatorPart_9_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_DarkMatter_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 100
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 200
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SingularityCell_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": 0,
+    "maxPower": 0
+  },
+  "Recipe_SpaceElevatorPart_11_C": {
+    "name": "Ballistic Warp Drive",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_SpaceElevatorPart_8_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_SingularityCell_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_QuantumOscillator_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_DarkMatter_C",
+        "amount": 40
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevatorPart_11_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": 500,
+    "maxPower": 1500
+  },
+  "Recipe_BlueprintDesigner_Mk3_C": {
+    "name": "Blueprint Designer Mk.3",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_TemporalProcessor_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ModularFrameFused_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_TimeCrystal_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_FicsiteMesh_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_BlueprintDesigner_MK3_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Hoverpack_C": {
+    "name": "Hoverpack",
+    "duration": 120,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Computer_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 40
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EquipmentDescriptorHoverPack_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FilterHazmat_C": {
+    "name": "Iodine-Infused Filter",
+    "duration": 16,
+    "ingredients": [
+      {
+        "item": "Desc_Filter_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HazmatFilter_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_HazmatSuit_C": {
+    "name": "Hazmat Suit",
+    "duration": 120,
+    "ingredients": [
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_AluminumPlate_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Fabric_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EquipmentDescriptorHazmatSuit_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RailroadBlockSignal_C": {
+    "name": "Block Signal",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Computer_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RailroadBlockSignal_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RailroadPathSignal_C": {
+    "name": "Path Signal",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Computer_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RailroadPathSignal_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_BlueprintDesigner_Mk2_C": {
+    "name": "Blueprint Designer Mk.2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Computer_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 100
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_BlueprintDesigner_MK2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipelineMK2_C": {
+    "name": "Pipeline Mk.2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipelineMK2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipelinePumpMK2_C": {
+    "name": "Pipeline Pump Mk.2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Motor_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipelinePumpMk2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RailroadEndStop_C": {
+    "name": "Buffer Stop",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RailroadEndStop_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_TrainDockingStation_C": {
+    "name": "Freight Platform",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TrainDockingStation_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_TrainDockingStationLiquid_C": {
+    "name": "Fluid Freight Platform",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TrainDockingStationLiquid_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_TrainPlatformEmpty_C": {
+    "name": "Empty Platform",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TrainPlatformEmpty_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_TrainPlatformEmpty_02_C": {
+    "name": "Empty Platform With Catwalk",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TrainPlatformEmpty_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_TrainStation_C": {
+    "name": "Train Station",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 200
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TrainStation_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RailroadTrack_C": {
+    "name": "Railway",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RailroadTrack_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FreightWagon_C": {
+    "name": "Freight Car",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FreightWagon_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Locomotive_C": {
+    "name": "Electric Locomotive",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Motor_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Locomotive_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_JetPack_C": {
+    "name": "Jetpack",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EquipmentDescriptorJetPack_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorBeltMk4_C": {
+    "name": "Conveyor Belt Mk.4",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorBeltMk4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorLiftMk4_C": {
+    "name": "Conveyor Lift Mk.4",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorLiftMk4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Truck_C": {
+    "name": "Truck",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Truck_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_GeneratorFuel_C": {
+    "name": "Fuel-Powered Generator",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 30
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GeneratorFuel_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_IndustrialTank_C": {
+    "name": "Industrial Fluid Buffer",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 25
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IndustrialTank_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Quickwire_C": {
+    "name": "Quickwire",
+    "duration": 5,
+    "ingredients": [
+      {
+        "item": "Desc_GoldIngot_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorBeltMk3_C": {
+    "name": "Conveyor Belt Mk.3",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorBeltMk3_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorLiftMk3_C": {
+    "name": "Conveyor Lift Mk.3",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorLiftMk3_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipeSupportStackable_C": {
+    "name": "Stackable Pipeline Support",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipeSupportStackable_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StorageContainerMk2_C": {
+    "name": "Industrial Storage Container",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StorageContainerMk2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_BlueprintDesigner_C": {
+    "name": "Blueprint Designer Mk.1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 100
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_BlueprintDesigner_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipeHyperStart_C": {
+    "name": "Hypertube Entrance",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipeHyperStart_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_HyperPoleStackable_C": {
+    "name": "Stackable Hypertube Support",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HyperPoleStackable_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_HyperTubeJunction_C": {
+    "name": "Hypertube Junction",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HyperTubeJunction_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_HyperTubeTJunction_C": {
+    "name": "Hypertube Branch",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HypertubeTJunction_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_HyperTubeWallSupport_C": {
+    "name": "Hypertube Wall Support",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HyperTubeWallSupport_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipeHyperSupport_C": {
+    "name": "Hypertube Support",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipeHyperSupport_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipeHyper_C": {
+    "name": "Hypertube",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipeHyper_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerStorageMk1_C": {
+    "name": "Power Storage",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerStorageMk1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerTower_C": {
+    "name": "Power Tower",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerTower_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerTowerPlatform_C": {
+    "name": "Power Tower Platform",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerTowerPlatform_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XenoBasher_C": {
+    "name": "Xeno-Basher",
+    "duration": 80,
+    "ingredients": [
+      {
+        "item": "BP_EquipmentDescriptorShockShank_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 500
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EquipmentDescriptorStunSpear_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_TruckStation_C": {
+    "name": "Truck Station",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TruckStation_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Tractor_C": {
+    "name": "Tractor",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Tractor_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorBeltMk2_C": {
+    "name": "Conveyor Belt Mk.2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorBeltMk2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorLiftMk2_C": {
+    "name": "Conveyor Lift Mk.2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorLiftMk2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorPoleStackable_C": {
+    "name": "Stackable Conveyor Pole",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorPoleStackable_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_JumpPadAdjustable_C": {
+    "name": "Jump Pad",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_JumpPadAdjustable_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_UJellyLandingPad_C": {
+    "name": "U-Jelly Landing Pad",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_GenericBiomass_C",
+        "amount": 200
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LandingPad_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Biofuel_C": {
+    "name": "Solid Biofuel",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_GenericBiomass_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Biofuel_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Chainsaw_C": {
+    "name": "Chainsaw",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 160
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 15
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Chainsaw_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Protein_Hog_C": {
+    "name": "Hog Protein",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_HogParts_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AlienProtein_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Protein_Spitter_C": {
+    "name": "Spitter Protein",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_SpitterParts_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AlienProtein_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Biomass_Mycelia_C": {
+    "name": "Biomass (Mycelia)",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_Mycelia_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GenericBiomass_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerCrystalShard_1_C": {
+    "name": "Power Shard (1)",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_Crystal_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CrystalShard_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Gunpowder_C": {
+    "name": "Black Powder",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_Coal_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Sulfur_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Gunpowder_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Mam_C": {
+    "name": "MAM",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 45
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Mam_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StoragePlayer_C": {
+    "name": "Personal Storage Box",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StoragePlayer_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ObjectScanner_C": {
+    "name": "Object Scanner",
+    "duration": 40,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EquipmentDescriptorObjectScanner_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorAttachmentMerger_C": {
+    "name": "Conveyor Merger",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorAttachmentMerger_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorAttachmentSplitter_C": {
+    "name": "Conveyor Splitter",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorAttachmentSplitter_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorLiftMk1_C": {
+    "name": "Conveyor Lift Mk.1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorLiftMk1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Ficsit_4x1_C": {
+    "name": "Half Foundation (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Ficsit_4x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Ficsit_4x2_C": {
+    "name": "Half Foundation (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Ficsit_4x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Ficsit_4x4_C": {
+    "name": "Half Foundation (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Ficsit_4x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Ficsit_8x1_C": {
+    "name": "Inner Corner Extension (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Ficsit_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Ficsit_8x2_C": {
+    "name": "Inner Corner Extension (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Ficsit_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Ficsit_8x4_C": {
+    "name": "Inner Corner Extension (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Ficsit_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Ficsit_4x1_C": {
+    "name": "Outer Corner Extension (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Ficsit_4x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Ficsit_4x2_C": {
+    "name": "Outer Corner Extension (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Ficsit_4x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Ficsit_4x4_C": {
+    "name": "Outer Corner Extension (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Ficsit_4x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_FicsitSet_8x1_01_C": {
+    "name": "Foundation Stairs (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_FicsitSet_8x1_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_FicsitSet_8x2_01_C": {
+    "name": "Foundation Stairs (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_FicsitSet_8x2_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_FicsitSet_8x4_01_C": {
+    "name": "Foundation Stairs (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_FicsitSet_8x4_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_8x1_01_C": {
+    "name": "Foundation (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_8x1_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_8x2_01_C": {
+    "name": "Foundation (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_8x2_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_8x4_01_C": {
+    "name": "Foundation (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_8x4_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipe_C": {
+    "name": "Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipe_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipe_02_C": {
+    "name": "Inverted Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipe_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeCorner_01_C": {
+    "name": "Inner Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeCorner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeCorner_02_C": {
+    "name": "Inverted Inner Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeCorner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeCorner_03_C": {
+    "name": "Outer Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeCorner_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeCorner_04_C": {
+    "name": "Inverted Outer Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeCorner_04_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_8x1_01_C": {
+    "name": "Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_8x1_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_8x2_01_C": {
+    "name": "Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_8x2_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_8x4_01_C": {
+    "name": "Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_8x4_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_8x4_Inverted_01_C": {
+    "name": "Inverted Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_8x4_Inverted_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_8x8x8_C": {
+    "name": "Double Ramp (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_8x8x8_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Diagonal_8x1_01_C": {
+    "name": "Down Corner Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Diagonal_8x1_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Diagonal_8x1_02_C": {
+    "name": "Up Corner Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Diagonal_8x1_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Diagonal_8x2_01_C": {
+    "name": "Down Corner Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Diagonal_8x2_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Diagonal_8x2_02_C": {
+    "name": "Up Corner Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Diagonal_8x2_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Diagonal_8x4_01_C": {
+    "name": "Down Corner Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Diagonal_8x4_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Diagonal_8x4_02_C": {
+    "name": "Up Corner Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Diagonal_8x4_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_C": {
+    "name": "Double Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_8x1_C": {
+    "name": "Double Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampInverted_8x1_C": {
+    "name": "Inverted Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampInverted_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampInverted_8x1_Corner_01_C": {
+    "name": "Inverted Up Corner (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampInverted_8x1_Corner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampInverted_8x1_Corner_02_C": {
+    "name": "Inverted Down Corner (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampInverted_8x1_Corner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampInverted_8x2_01_C": {
+    "name": "Inverted Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampInverted_8x2_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampInverted_8x2_Corner_01_C": {
+    "name": "Inverted Up Corner (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampInverted_8x2_Corner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampInverted_8x2_Corner_02_C": {
+    "name": "Inverted Down Corner (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampInverted_8x2_Corner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampInverted_8x4_Corner_01_C": {
+    "name": "Inverted Up Corner (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampInverted_8x4_Corner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampInverted_8x4_Corner_02_C": {
+    "name": "Inverted Down Corner (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampInverted_8x4_Corner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_LookoutTower_C": {
+    "name": "Lookout Tower",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LookoutTower_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_BigGarageDoor_16x8_C": {
+    "name": "Roll-Up Gate",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_BigGarageDoor_16x8_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_8x4_01_C": {
+    "name": "Basic Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_8x4_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Conveyor_8x4_01_C": {
+    "name": "Conveyor Wall x 3",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Conveyor_8x4_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Conveyor_8x4_02_C": {
+    "name": "Conveyor Wall x 2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Conveyor_8x4_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Conveyor_8x4_03_C": {
+    "name": "Conveyor Wall x 1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Conveyor_8x4_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Door_8x4_01_C": {
+    "name": "Center Door Wall",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Door_8x4_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Door_8x4_03_C": {
+    "name": "Side Door Wall",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Door_8x4_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Gate_8x4_01_C": {
+    "name": "Gate Hole Wall",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Gate_8x4_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_8x1_C": {
+    "name": "Basic Wall (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_8x4_Corner_01_C": {
+    "name": "Tilted Corner Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x4_Corner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_8x4_Corner_02_C": {
+    "name": "Tilted Concave Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x4_Corner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_8x8_Corner_01_C": {
+    "name": "Tilted Corner Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x8_Corner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_8x8_Corner_02_C": {
+    "name": "Tilted Concave Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x8_Corner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_Angular_8x4_C": {
+    "name": "Tilted Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_Angular_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_Angular_8x8_C": {
+    "name": "Tilted Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_Angular_8x8_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_FlipTris_8x1_C": {
+    "name": "Inverted Ramp Wall (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x1_FlipTris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_FlipTris_8x2_C": {
+    "name": "Inverted Ramp Wall (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x2_FlipTris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_FlipTris_8x4_C": {
+    "name": "Inverted Ramp Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x4_FlipTris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_FlipTris_8x8_C": {
+    "name": "Inverted Ramp Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x8_FlipTris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_Tris_8x1_C": {
+    "name": "Ramp Wall (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x1_Tris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_Tris_8x2_C": {
+    "name": "Ramp Wall (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x2_Tris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_Tris_8x4_C": {
+    "name": "Ramp Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x4_Tris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Orange_Tris_8x8_C": {
+    "name": "Ramp Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Orange_8x8_Tris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Window_8x4_01_C": {
+    "name": "Single Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Window_8x4_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Window_8x4_02_C": {
+    "name": "Frame Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Window_8x4_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Window_8x4_03_C": {
+    "name": "Panel Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Window_8x4_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Window_8x4_04_C": {
+    "name": "Reinforced Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Window_8x4_04_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_Concrete_8x4_C": {
+    "name": "Inverted Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipe_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_ConcreteInCorner_8x4_C": {
+    "name": "Inverted Inner Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipeInCorner_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_ConcreteOutCorner_8x4_C": {
+    "name": "Inverted Outer Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipeOutCorner_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_Concrete_8x1_C": {
+    "name": "Foundation (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_Concrete_8x2_C": {
+    "name": "Foundation (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_Concrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_Concrete_8x4_C": {
+    "name": "Foundation (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Concrete_8x1_C": {
+    "name": "Inverted Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Concrete_8x2_C": {
+    "name": "Inverted Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Concrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Concrete_8x4_C": {
+    "name": "Inverted Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Concrete_8x1_C": {
+    "name": "Inverted Down Corner (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Concrete_8x2_C": {
+    "name": "Inverted Down Corner (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Concrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Concrete_8x4_C": {
+    "name": "Inverted Down Corner (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Concrete_8x1_C": {
+    "name": "Inverted Up Corner (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Concrete_8x2_C": {
+    "name": "Inverted Up Corner (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Concrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Concrete_8x4_C": {
+    "name": "Inverted Up Corner (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipe_Concrete_8x4_C": {
+    "name": "Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipe_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeInCorner_Concrete_8x4_C": {
+    "name": "Inner Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeInCorner_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Concrete_8x1_C": {
+    "name": "Half Foundation (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Concrete_8x2_C": {
+    "name": "Half Foundation (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Concrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Concrete_8x4_C": {
+    "name": "Half Foundation (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Concrete_8x1_C": {
+    "name": "Inner Corner Extension (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Concrete_8x2_C": {
+    "name": "Inner Corner Extension (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Concrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Concrete_8x4_C": {
+    "name": "Inner Corner Extension (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Concrete_4x1_C": {
+    "name": "Outer Corner Extension (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Concrete_4x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Concrete_4x2_C": {
+    "name": "Outer Corner Extension (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Concrete_4x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Concrete_4x4_C": {
+    "name": "Outer Corner Extension (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Concrete_4x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeOutCorner_Concrete_8x4_C": {
+    "name": "Outer Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeOutCorner_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Concrete_8x1_C": {
+    "name": "Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Concrete_8x2_C": {
+    "name": "Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Concrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Concrete_8x4_C": {
+    "name": "Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Concrete_8x1_C": {
+    "name": "Down Corner Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Concrete_8x2_C": {
+    "name": "Down Corner Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Concrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Concrete_8x4_C": {
+    "name": "Down Corner Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Concrete_8x1_C": {
+    "name": "Up Corner Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Concrete_8x2_C": {
+    "name": "Up Corner Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Concrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Concrete_8x4_C": {
+    "name": "Up Corner Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Concrete_8x1_C": {
+    "name": "Double Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Concrete_8x2_C": {
+    "name": "Double Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Concrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Concrete_8x4_C": {
+    "name": "Double Ramp (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_Concrete_8x1_C": {
+    "name": "Foundation Stairs (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_Concrete_8x2_C": {
+    "name": "Foundation Stairs (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_Concrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_Concrete_8x4_C": {
+    "name": "Foundation Stairs (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_Grip_8x4_C": {
+    "name": "Inverted Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipe_Grip_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_GripInCorner_8x4_C": {
+    "name": "Inverted Inner Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipeInCorner_Grip_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_GripOutCorner_8x4_C": {
+    "name": "Inverted Outer Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipeOutCorner_Grip_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_Metal_8x1_C": {
+    "name": "Foundation (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_Metal_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_Metal_8x2_C": {
+    "name": "Foundation (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_Metal_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_Metal_8x4_C": {
+    "name": "Foundation (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_Metal_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Metal_8x1_C": {
+    "name": "Inverted Down Corner (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Metal_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Metal_8x2_C": {
+    "name": "Inverted Down Corner (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Metal_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Metal_8x4_C": {
+    "name": "Inverted Down Corner (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Metal_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Metal_8x1_C": {
+    "name": "Inverted Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Metal_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Metal_8x2_C": {
+    "name": "Inverted Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Metal_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Metal_8x4_C": {
+    "name": "Inverted Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Metal_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Metal_8x1_C": {
+    "name": "Inverted Up Corner (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Metal_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Metal_8x2_C": {
+    "name": "Inverted Up Corner (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Metal_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Metal_8x4_C": {
+    "name": "Inverted Up Corner (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Metal_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipe_Grip_8x4_C": {
+    "name": "Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipe_Grip_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeInCorner_Grip_8x4_C": {
+    "name": "Inner Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeInCorner_Grip_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Grip_8x1_C": {
+    "name": "Half Foundation (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Grip_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Grip_8x2_C": {
+    "name": "Half Foundation (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Grip_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Grip_8x4_C": {
+    "name": "Half Foundation (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Grip_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Grip_8x1_C": {
+    "name": "Inner Corner Extension (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Grip_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Grip_8x2_C": {
+    "name": "Inner Corner Extension (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Grip_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Grip_8x4_C": {
+    "name": "Inner Corner Extension (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Grip_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Grip_4x1_C": {
+    "name": "Outer Corner Extension (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Grip_4x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Grip_4x2_C": {
+    "name": "Outer Corner Extension (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Grip_4x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Grip_4x4_C": {
+    "name": "Outer Corner Extension (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Grip_4x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeOutCorner_Grip_8x4_C": {
+    "name": "Outer Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeOutCorner_Grip_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Metal_8x1_C": {
+    "name": "Down Corner Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Metal_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Metal_8x2_C": {
+    "name": "Down Corner Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Metal_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Metal_8x4_C": {
+    "name": "Down Corner Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Metal_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Metal_8x1_C": {
+    "name": "Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Metal_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Metal_8x2_C": {
+    "name": "Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Metal_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Metal_8x4_C": {
+    "name": "Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Metal_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Metal_8x1_C": {
+    "name": "Up Corner Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Metal_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Metal_8x2_C": {
+    "name": "Up Corner Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Metal_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Metal_8x4_C": {
+    "name": "Up Corner Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Metal_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Metal_8x1_C": {
+    "name": "Double Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Metal_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Metal_8x2_C": {
+    "name": "Double Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Metal_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Metal_8x4_C": {
+    "name": "Double Ramp (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Metal_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_GripMetal_8x1_C": {
+    "name": "Foundation Stairs (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_GripMetal_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_GripMetal_8x2_C": {
+    "name": "Foundation Stairs (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_GripMetal_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_GripMetal_8x4_C": {
+    "name": "Foundation Stairs (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_GripMetal_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_ConcretePolished_8x4_C": {
+    "name": "Inverted Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipe_ConcretePolished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_ConcretePolishedInCorner_8x4_C": {
+    "name": "Inverted Inner Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipeInCorner_ConcretePolished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_ConcretePolishedOutCorner_8x4_C": {
+    "name": "Inverted Outer Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipeOutCorner_ConcretePolished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_ConcretePolished_8x1_C": {
+    "name": "Foundation (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_ConcretePolished_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Polished_8x1_C": {
+    "name": "Inverted Down Corner (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Polished_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Polished_8x2_C": {
+    "name": "Inverted Down Corner (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Polished_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Polished_8x4_C": {
+    "name": "Inverted Down Corner (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Polished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Polished_8x1_C": {
+    "name": "Inverted Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Polished_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Polished_8x2_C": {
+    "name": "Inverted Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Polished_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Polished_8x4_C": {
+    "name": "Inverted Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Polished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Polished_8x1_C": {
+    "name": "Inverted Up Corner (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Polished_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Polished_8x2_C": {
+    "name": "Inverted Up Corner (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Polished_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Polished_8x4_C": {
+    "name": "Inverted Up Corner (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Polished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipe_ConcretePolished_8x4_C": {
+    "name": "Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipe_ConcretePolished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeInCorner_ConcretePolished_8x4_C": {
+    "name": "Inner Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeInCorner_ConcretePolished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_PolishedConcrete_8x1_C": {
+    "name": "Half Foundation (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_PolishedConcrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_PolishedConcrete_8x2_C": {
+    "name": "Half Foundation (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_PolishedConcrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_PolishedConcrete_8x4_C": {
+    "name": "Half Foundation (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_PolishedConcrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_PolishedConcrete_8x1_C": {
+    "name": "Inner Corner Extension (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_PolishedConcrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_PolishedConcrete_8x2_C": {
+    "name": "Inner Corner Extension (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_PolishedConcrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_PolishedConcrete_8x4_C": {
+    "name": "Inner Corner Extension (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_PolishedConcrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_PolishedConcrete_4x1_C": {
+    "name": "Outer Corner Extension (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_PolishedConcrete_4x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_PolishedConcrete_4x2_C": {
+    "name": "Outer Corner Extension (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_PolishedConcrete_4x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_PolishedConcrete_4x4_C": {
+    "name": "Outer Corner Extension (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_PolishedConcrete_4x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeOutCorner_ConcretePolished_8x4_C": {
+    "name": "Outer Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeOutCorner_ConcretePolished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Polished_8x1_C": {
+    "name": "Down Corner Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Polished_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Polished_8x2_C": {
+    "name": "Down Corner Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Polished_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Polished_8x4_C": {
+    "name": "Down Corner Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Polished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Polished_8x1_C": {
+    "name": "Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Polished_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Polished_8x2_C": {
+    "name": "Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Polished_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Polished_8x4_C": {
+    "name": "Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Polished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Polished_8x1_C": {
+    "name": "Up Corner Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Polished_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Polished_8x2_C": {
+    "name": "Up Corner Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Polished_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Polished_8x4_C": {
+    "name": "Up Corner Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Polished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Polished_8x1_C": {
+    "name": "Double Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Polished_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Polished_8x2_C": {
+    "name": "Double Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Polished_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Polished_8x4_C": {
+    "name": "Double Ramp (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Polished_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_PolishedConcrete_8x1_C": {
+    "name": "Foundation Stairs (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_PolishedConcrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_PolishedConcrete_8x2_C": {
+    "name": "Foundation Stairs (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_PolishedConcrete_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_PolishedConcrete_8x4_C": {
+    "name": "Foundation Stairs (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_PolishedConcrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_Asphalt_8x4_C": {
+    "name": "Inverted Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipe_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_AsphaltInCorner_8x4_C": {
+    "name": "Inverted Inner Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipeInCorner_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_DownQuarterPipe_AsphaltOutCorner_8x4_C": {
+    "name": "Inverted Outer Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_DownQuarterPipeOutCorner_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_Asphalt_8x1_C": {
+    "name": "Foundation (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_Asphalt_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_Asphalt_8x2_C": {
+    "name": "Foundation (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_Asphalt_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_Asphalt_8x4_C": {
+    "name": "Foundation (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Asphalt_8x1_C": {
+    "name": "Inverted Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Asphalt_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Asphalt_8x2_C": {
+    "name": "Inverted Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Asphalt_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_Asphalt_8x4_C": {
+    "name": "Inverted Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Asphalt_8x1_C": {
+    "name": "Inverted Down Corner (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Asphalt_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Asphalt_8x2_C": {
+    "name": "Inverted Down Corner (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Asphalt_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_DCorner_Asphalt_8x4_C": {
+    "name": "Inverted Down Corner (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_DCorner_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Asphalt_8x1_C": {
+    "name": "Inverted Up Corner (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Asphalt_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Asphalt_8x2_C": {
+    "name": "Inverted Up Corner (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Asphalt_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_InvertedRamp_UCorner_Asphalt_8x4_C": {
+    "name": "Inverted Up Corner (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_InvertedRamp_UCorner_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipe_Asphalt_8x4_C": {
+    "name": "Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipe_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeInCorner_Asphalt_8x4_C": {
+    "name": "Inner Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeInCorner_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Asphalt_8x1_C": {
+    "name": "Half Foundation (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Asphalt_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Asphalt_8x2_C": {
+    "name": "Half Foundation (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Asphalt_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddle_Asphalt_8x4_C": {
+    "name": "Half Foundation (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddle_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Asphalt_8x1_C": {
+    "name": "Inner Corner Extension (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Asphalt_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Asphalt_8x2_C": {
+    "name": "Inner Corner Extension (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Asphalt_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleInCorner_Asphalt_8x4_C": {
+    "name": "Inner Corner Extension (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleInCorner_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Asphalt_4x1_C": {
+    "name": "Outer Corner Extension (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Asphalt_4x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Asphalt_4x2_C": {
+    "name": "Outer Corner Extension (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Asphalt_4x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeMiddleOutCorner_Asphalt_4x4_C": {
+    "name": "Outer Corner Extension (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeMiddleOutCorner_Asphalt_4x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_QuarterPipeOutCorner_Asphalt_8x4_C": {
+    "name": "Outer Corner Quarter Pipe",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_QuarterPipeOutCorner_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Asphalt_8x1_C": {
+    "name": "Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Asphalt_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Asphalt_8x2_C": {
+    "name": "Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Asphalt_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Asphalt_8x4_C": {
+    "name": "Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Asphalt_8x1_C": {
+    "name": "Down Corner Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Asphalt_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Asphalt_8x2_C": {
+    "name": "Down Corner Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Asphalt_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_DownCorner_Asphalt_8x4_C": {
+    "name": "Down Corner Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_DownCorner_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Asphalt_8x1_C": {
+    "name": "Up Corner Ramp (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Asphalt_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Asphalt_8x2_C": {
+    "name": "Up Corner Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Asphalt_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_UpCorner_Asphalt_8x4_C": {
+    "name": "Up Corner Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_UpCorner_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Asphalt_8x1_C": {
+    "name": "Double Ramp (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Asphalt_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Asphalt_8x2_C": {
+    "name": "Double Ramp (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Asphalt_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RampDouble_Asphalt_8x4_C": {
+    "name": "Double Ramp (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RampDouble_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_Asphalt_8x1_C": {
+    "name": "Foundation Stairs (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_Asphalt_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_Asphalt_8x2_C": {
+    "name": "Foundation Stairs (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_Asphalt_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Stair_Asphalt_8x4_C": {
+    "name": "Foundation Stairs (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Stair_Asphalt_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Protein_Stinger_C": {
+    "name": "Stinger Protein",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_StingerParts_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AlienProtein_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Protein_Crab_C": {
+    "name": "Hatcher Protein",
+    "duration": 3,
+    "ingredients": [
+      {
+        "item": "Desc_HatcherParts_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AlienProtein_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_AlienDNACapsule_C": {
+    "name": "Alien DNA Capsule",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_AlienProtein_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AlienDNACapsule_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Biomass_AlienProtein_C": {
+    "name": "Biomass (Alien Protein)",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_AlienProtein_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GenericBiomass_C",
+        "amount": 100
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_MedicinalInhalerAlienOrgans_C": {
+    "name": "Protein Inhaler",
+    "duration": 20,
+    "ingredients": [
+      {
+        "item": "Desc_AlienProtein_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Nut_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Medkit_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpikedRebar_C": {
+    "name": "Iron Rebar",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpikedRebar_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RebarGun_C": {
+    "name": "Rebar Gun",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 16
+      },
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RebarGunProjectile_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_AlienPowerBuilding_C": {
+    "name": "Alien Power Augmenter",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_WAT1_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SAMFluctuator_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 100
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Motor_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_Computer_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AlienPowerBuilding_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CentralStorage_C": {
+    "name": "Dimensional Depot Uploader",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_WAT2_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_SAMFluctuator_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CentralStorage_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_AlienPowerFuel_C": {
+    "name": "Alien Power Matrix",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_SAMFluctuator_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_CrystalShard_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_QuantumOscillator_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_QuantumEnergy_C",
+        "amount": 24
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_AlienPowerFuel_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_DarkEnergy_C",
+        "amount": 24
+      }
+    ],
+    "producedIn": [
+      "Desc_QuantumEncoder_C"
+    ],
+    "alternate": false,
+    "minPower": 0,
+    "maxPower": 2000
+  },
+  "Recipe_GeneratorGeoThermal_C": {
+    "name": "Geothermal Generator",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 250
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GeneratorGeoThermal_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorAttachmentSplitterProgrammable_C": {
+    "name": "Programmable Splitter",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Computer_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_CircuitBoardHighSpeed_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorAttachmentSplitterProgrammable_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CartridgeSmart_C": {
+    "name": "Homing Rifle Ammo",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_CartridgeStandard_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CartridgeSmartProjectile_C",
+        "amount": 10
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerPoleMk3_C": {
+    "name": "Power Pole Mk.3",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerPoleMk3_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PriorityPowerSwitch_C": {
+    "name": "Priority Power Switch",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PriorityPowerSwitch_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_BladeRunners_C": {
+    "name": "Blade Runners",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EquipmentDescriptorJumpingStilts_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerPoleMk2_C": {
+    "name": "Power Pole Mk.2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerPoleMk2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerSwitch_C": {
+    "name": "Power Switch",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_CircuitBoardHighSpeed_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerSwitch_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorAttachmentSplitterSmart_C": {
+    "name": "Smart Splitter",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_CircuitBoardHighSpeed_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorAttachmentSplitterSmart_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Rebar_Stunshot_C": {
+    "name": "Stun Rebar",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_SpikedRebar_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Rebar_Stunshot_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ZipLine_C": {
+    "name": "Zipline",
+    "duration": 40,
+    "ingredients": [
+      {
+        "item": "BP_EquipmentDescriptorShockShank_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 30
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EqDescZipLine_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FilterGasMask_C": {
+    "name": "Gas Filter",
+    "duration": 8,
+    "ingredients": [
+      {
+        "item": "Desc_Fabric_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Coal_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Filter_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Gasmask_C": {
+    "name": "Gas Mask",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_Fabric_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EquipmentDescriptorGasmask_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_NobeliskGas_C": {
+    "name": "Gas Nobelisk",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_NobeliskExplosive_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_GenericBiomass_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NobeliskGas_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_TherapeuticInhaler_C": {
+    "name": "Therapeutic Inhaler",
+    "duration": 20,
+    "ingredients": [
+      {
+        "item": "Desc_Mycelia_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_AlienProtein_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Shroom_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Medkit_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_MedicinalInhaler_C": {
+    "name": "Vitamin Inhaler",
+    "duration": 20,
+    "ingredients": [
+      {
+        "item": "Desc_Mycelia_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Berry_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Medkit_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Parachute_C": {
+    "name": "Parachute",
+    "duration": 40,
+    "ingredients": [
+      {
+        "item": "Desc_Fabric_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Parachute_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Alternate_PolyesterFabric_C": {
+    "name": "Polyester Fabric",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_PolymerResin_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Water_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Fabric_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": true,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Fabric_C": {
+    "name": "Fabric",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_Mycelia_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_GenericBiomass_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Fabric_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_NutritionalInhaler_C": {
+    "name": "Nutritional Inhaler",
+    "duration": 20,
+    "ingredients": [
+      {
+        "item": "Desc_Shroom_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Berry_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Nut_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Medkit_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SyntheticPowerShard_C": {
+    "name": "Synthetic Power Shard",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_TimeCrystal_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_DarkMatter_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 12
+      },
+      {
+        "item": "Desc_QuantumEnergy_C",
+        "amount": 12
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CrystalShard_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_DarkEnergy_C",
+        "amount": 12
+      }
+    ],
+    "producedIn": [
+      "Desc_QuantumEncoder_C"
+    ],
+    "alternate": false,
+    "minPower": 0,
+    "maxPower": 2000
+  },
+  "Recipe_PowerCrystalShard_3_C": {
+    "name": "Power Shard (5)",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_Crystal_mk3_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CrystalShard_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerCrystalShard_2_C": {
+    "name": "Power Shard (2)",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Crystal_mk2_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CrystalShard_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorAttachmentMergerPriority_C": {
+    "name": "Priority Merger",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorAttachmentMergerPriority_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_RadarTower_C": {
+    "name": "Radar Tower",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Computer_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_ModularFrameHeavy_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 100
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_RadarTower_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_NobeliskShockwave_C": {
+    "name": "Pulse Nobelisk",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_NobeliskExplosive_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NobeliskShockwave_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Explorer_C": {
+    "name": "Explorer",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Motor_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 15
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Explorer_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Rebar_Spreadshot_C": {
+    "name": "Shatter Rebar",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_SpikedRebar_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Rebar_Spreadshot_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CartridgeChaos_Packaged_C": {
+    "name": "Turbo Rifle Ammo",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_CartridgeStandard_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_TurboFuel_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CartridgeChaos_C",
+        "amount": 50
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CartridgeChaos_C": {
+    "name": "Turbo Rifle Ammo",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_CartridgeStandard_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_AluminumCasing_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_LiquidTurboFuel_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CartridgeChaos_C",
+        "amount": 50
+      }
+    ],
+    "producedIn": [
+      "Desc_Blender_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_NobeliskNuke_C": {
+    "name": "Nuke Nobelisk",
+    "duration": 120,
+    "ingredients": [
+      {
+        "item": "Desc_NobeliskExplosive_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_UraniumCell_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_GunpowderMK2_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_CircuitBoardHighSpeed_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NobeliskNuke_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Cartridge_C": {
+    "name": "Rifle Ammo",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_GunpowderMK2_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CartridgeStandard_C",
+        "amount": 15
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Rebar_Explosive_C": {
+    "name": "Explosive Rebar",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_SpikedRebar_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_GunpowderMK2_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Rebar_Explosive_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ManufacturerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceRifleMk1_C": {
+    "name": "Rifle",
+    "duration": 120,
+    "ingredients": [
+      {
+        "item": "Desc_Motor_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Rubber_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 250
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EquipmentDescriptorRifle_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_NobeliskCluster_C": {
+    "name": "Cluster Nobelisk",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_NobeliskExplosive_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_GunpowderMK2_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NobeliskCluster_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Nobelisk_C": {
+    "name": "Nobelisk",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_Gunpowder_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_NobeliskExplosive_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_NobeliskDetonator_C": {
+    "name": "Nobelisk Detonator",
+    "duration": 80,
+    "ingredients": [
+      {
+        "item": "BP_EquipmentDescriptorObjectScanner_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 50
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EquipmentDescriptorNobeliskDetonator_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_GunpowderMK2_C": {
+    "name": "Smokeless Powder",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_Gunpowder_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_HeavyOilResidue_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GunpowderMK2_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_OilRefinery_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XmasWreath_C": {
+    "name": "FICSMAS Wreath",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_XmasBranch_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_XmasBallCluster_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_XmasWreath_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Snowball_C": {
+    "name": "Snowball",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Snow_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SnowballProjectile_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_WreathDecor_C": {
+    "name": "FICSMAS Decoration",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_XmasWreath_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_XmasBow_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_WreathDecor_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XmasStar_C": {
+    "name": "FICSMAS Wonder Star",
+    "duration": 60,
+    "ingredients": [
+      {
+        "item": "Desc_XmasWreath_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_CandyCane_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_XmasStar_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XmasBall3_C": {
+    "name": "Copper FICSMAS Ornament",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_XmasBall1_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_XmasBall3_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XmasBall4_C": {
+    "name": "Iron FICSMAS Ornament",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_XmasBall2_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_IronIngot_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_XmasBall4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_FoundryMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SnowCannon_C": {
+    "name": "FICSMAS Snow Cannon",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_XmasBow_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Snow_C",
+        "amount": 100
+      },
+      {
+        "item": "Desc_XmasBall3_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SnowCannon_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SnowDispenser_C": {
+    "name": "FICSMAS Snow Dispenser",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CandyCane_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Snow_C",
+        "amount": 100
+      },
+      {
+        "item": "Desc_XmasBall4_C",
+        "amount": 20
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SnowDispenser_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_xmassLights_C": {
+    "name": "FICSMAS Power Light",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cable_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_XmasBallCluster_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_xmassLights_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XmasBallCluster_C": {
+    "name": "FICSMAS Ornament Bundle",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_XmasBall3_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_XmasBall4_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_XmasBallCluster_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XmasBall1_C": {
+    "name": "Red FICSMAS Ornament",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Gift_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_XmasBall1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_SmelterMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XmasBall2_C": {
+    "name": "Blue FICSMAS Ornament",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Gift_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_XmasBall2_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_SmelterMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_TreeGiftProducer_C": {
+    "name": "FICSMAS Gift Tree",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Gift_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_XmasBranch_C",
+        "amount": 100
+      },
+      {
+        "item": "Desc_XmasBall1_C",
+        "amount": 30
+      },
+      {
+        "item": "Desc_XmasBall2_C",
+        "amount": 30
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TreeGiftProducer_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Snowman_C": {
+    "name": "FICSMAS Snowman",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Snow_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_CandyCane_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_XmasBow_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_XmasBall1_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_XmasBall2_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Snowman_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Snow_C": {
+    "name": "FICSMAS Actual Snow",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Gift_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Snow_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XMassTree_C": {
+    "name": "Giant FICSMAS Tree",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_XmasBranch_C",
+        "amount": 100
+      },
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 500
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_XMassTree_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XmasBranch_C": {
+    "name": "FICSMAS Tree Branch",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_Gift_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_XmasBranch_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CandyCaneDecor_C": {
+    "name": "FICSMAS Candy Cane",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CandyCane_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_XmasBow_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CandyCaneDecor_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_XmasBow_C": {
+    "name": "FICSMAS Bow",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Gift_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_XmasBow_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CandyCane_C": {
+    "name": "Candy Cane",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_Gift_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CandyCane_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CandyCaneBasher_C": {
+    "name": "Candy Cane Basher",
+    "duration": 80,
+    "ingredients": [
+      {
+        "item": "BP_EquipmentDescriptorShockShank_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_CandyCane_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_Gift_C",
+        "amount": 15
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_EquipmentDescriptorCandyCane_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_BigGarageDoor_16x8_Concrete_C": {
+    "name": "Roll-Up Gate",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_BigGarageDoor_16x8_Concrete_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x1_C": {
+    "name": "Basic Wall (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x4_C": {
+    "name": "Basic Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x4_ConveyorHole_01_C": {
+    "name": "Conveyor Wall x 1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_ConveyorHole_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x4_ConveyorHole_02_C": {
+    "name": "Conveyor Wall x 2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_ConveyorHole_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x4_ConveyorHole_03_C": {
+    "name": "Conveyor Wall x 3",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_ConveyorHole_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x4_Corner_01_C": {
+    "name": "Tilted Corner Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_Corner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x4_Corner_2_C": {
+    "name": "Tilted Concave Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_Corner_2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x4_Window_01_C": {
+    "name": "Single Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_Window_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x4_Window_02_C": {
+    "name": "Frame Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_Window_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x4_Window_03_C": {
+    "name": "Panel Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_Window_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x4_Window_04_C": {
+    "name": "Reinforced Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_Window_04_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x8_Corner_01_C": {
+    "name": "Tilted Corner Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x8_Corner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_8x8_Corner_2_C": {
+    "name": "Tilted Concave Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x8_Corner_2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_Angular_8x4_C": {
+    "name": "Tilted Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_Angular_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_Angular_8x8_C": {
+    "name": "Tilted Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_Angular_8x8_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_CDoor_8x4_C": {
+    "name": "Center Door Wall",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_CDoor_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_FlipTris_8x1_C": {
+    "name": "Inverted Ramp Wall (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x1_FlipTris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_FlipTris_8x2_C": {
+    "name": "Inverted Ramp Wall (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x2_FlipTris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_FlipTris_8x4_C": {
+    "name": "Inverted Ramp Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_FlipTris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_FlipTris_8x8_C": {
+    "name": "Inverted Ramp Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x8_FlipTris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_Gate_8x4_C": {
+    "name": "Gate Hole Wall",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_Gate_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_SDoor_8x4_C": {
+    "name": "Side Door Wall",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_SDoor_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_Tris_8x1_C": {
+    "name": "Ramp Wall (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x1_Tris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_Tris_8x2_C": {
+    "name": "Ramp Wall (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x2_Tris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_Tris_8x4_C": {
+    "name": "Ramp Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x4_Tris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Concrete_Tris_8x8_C": {
+    "name": "Ramp Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Concrete_8x8_Tris_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_BigGarageDoor_16x8_Steel_C": {
+    "name": "Roll-Up Gate",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_BigGarageDoor_16x8_Steel_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_8x4_Gate_01_C": {
+    "name": "Gate Hole Wall",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_8x4_Gate_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_8x4_Window_01_C": {
+    "name": "Single Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_8x4_Window_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_8x4_Window_02_C": {
+    "name": "Reinforced Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_8x4_Window_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_8x4_Window_03_C": {
+    "name": "Frame Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_8x4_Window_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_8x4_Window_04_C": {
+    "name": "Panel Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_8x4_Window_04_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Steel_8x4_Corner_01_C": {
+    "name": "Tilted Corner Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Steel_8x4_Corner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Steel_8x4_Corner_2_C": {
+    "name": "Tilted Concave Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Steel_8x4_Corner_2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Steel_8x8_Corner_01_C": {
+    "name": "Tilted Corner Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Steel_8x8_Corner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Steel_8x8_Corner_2_C": {
+    "name": "Tilted Concave Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Steel_8x8_Corner_2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_8x1_C": {
+    "name": "Basic Wall (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_FlipTris_8x1_C": {
+    "name": "Inverted Ramp Wall (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_FlipTris_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_FlipTris_8x2_C": {
+    "name": "Inverted Ramp Wall (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_FlipTris_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_FlipTris_8x4_C": {
+    "name": "Inverted Ramp Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_FlipTris_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_FlipTris_8x8_C": {
+    "name": "Inverted Ramp Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_FlipTris_8x8_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_Tris_8x1_C": {
+    "name": "Ramp Wall (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_Tris_8x1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_Tris_8x2_C": {
+    "name": "Ramp Wall (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_Tris_8x2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_Tris_8x4_C": {
+    "name": "Ramp Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_Tris_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SteelWall_Tris_8x8_C": {
+    "name": "Ramp Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SteelWall_Tris_8x8_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_8x4_02_C": {
+    "name": "Basic Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_8x4_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Conveyor_8x4_01_Steel_C": {
+    "name": "Conveyor Wall x 3",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Conveyor_8x4_01_Steel_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Conveyor_8x4_02_Steel_C": {
+    "name": "Conveyor Wall x 2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Conveyor_8x4_02_Steel_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Conveyor_8x4_03_Steel_C": {
+    "name": "Conveyor Wall x 1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Conveyor_8x4_03_Steel_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Door_8x4_01_Steel_C": {
+    "name": "Center Door Wall",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Door_8x4_01_Steel_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Door_8x4_03_Steel_C": {
+    "name": "Side Door Wall",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Door_8x4_03_Steel_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_WallSet_Steel_Angular_8x4_C": {
+    "name": "Tilted Wall (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_WallSet_Steel_Angular_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_WallSet_Steel_Angular_8x8_C": {
+    "name": "Tilted Wall (8 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_WallSet_Steel_Angular_8x8_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Flat_Frame_01_C": {
+    "name": "Frame Floor",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Flat_Frame_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Foundation_Frame_01_C": {
+    "name": "Frame Foundation",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Foundation_Frame_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FoundationGlass_01_C": {
+    "name": "Glass Frame Foundation",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FoundationGlass_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Frame_01_C": {
+    "name": "Frame Ramp",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Frame_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ramp_Frame_Inverted_01_C": {
+    "name": "Inverted Frame Ramp",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ramp_Frame_Inverted_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Frame_01_C": {
+    "name": "Frame Wall",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Frame_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Railing_01_C": {
+    "name": "Modern Railing",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Railing_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pillar_Small_Metal_C": {
+    "name": "Small Metal Pillar",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Pillar_Small_Metal_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PillarBase_Small_C": {
+    "name": "Small Pillar Support",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PillarBase_Small_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PillarBase_C": {
+    "name": "Big Pillar Support",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PillarBase_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PillarMiddle_C": {
+    "name": "Big Metal Pillar",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PillarMiddle_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Ladder_C": {
+    "name": "Ladder",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Ladder_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FactoryCart_C": {
+    "name": "Factory Cart™",
+    "duration": 20,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GolfCart_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CyberWagon_C": {
+    "name": "Cyber Wagon",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CyberWagon_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Gate_Automated_8x4_C": {
+    "name": "Automated Gate",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Gate_Automated_8x4_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_HyperTubeWallHole_C": {
+    "name": "Hypertube Wall Hole",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_HyperTubeWallHole_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipeSupportWallHole_C": {
+    "name": "Pipeline Wall Hole",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipelineSupportWallHole_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FoundationPassthrough_Pipe_C": {
+    "name": "Pipeline Floor Hole",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FoundationPassthrough_Pipe_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerPoleWallDouble_C": {
+    "name": "Double Wall Outlet Mk.1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Wire_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerPoleWallDouble_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerPoleWallDoubleMk2_C": {
+    "name": "Double Wall Outlet Mk.2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 16
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerPoleWallDoubleMk2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerPoleWallMk2_C": {
+    "name": "Wall Outlet Mk.2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 8
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerPoleWallMk2_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerPoleWallDoubleMk3_C": {
+    "name": "Double Wall Outlet Mk.3",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerPoleWallDoubleMk3_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PowerPoleWallMk3_C": {
+    "name": "Wall Outlet Mk.3",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedConnector_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_SteelPipe_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PowerPoleWallMk3_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_LargeFan_C": {
+    "name": "Large Fan",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LargeFan_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_LargeVent_C": {
+    "name": "Large Vent",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LargeVent_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StreetLight_C": {
+    "name": "Street Light",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StreetLight_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_CeilingLight_C": {
+    "name": "Ceiling Light",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 50
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 16
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CeilingLight_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FloodlightPole_C": {
+    "name": "Flood Light Tower",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FloodlightPole_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FloodlightWall_C": {
+    "name": "Wall-Mounted Flood Light",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_HighSpeedWire_C",
+        "amount": 25
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FloodlightWall_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StackableShelf_C": {
+    "name": "Basic Shelf Unit",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StackableShelf_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Orange_01_C": {
+    "name": "Flat Roof",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Orange_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Orange_02_C": {
+    "name": "Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Orange_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Orange_03_C": {
+    "name": "Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Orange_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Orange_04_C": {
+    "name": "Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Orange_04_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Orange_InCorner_01_C": {
+    "name": "Inner Corner Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Orange_InCorner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Orange_InCorner_02_C": {
+    "name": "Inner Corner Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Orange_InCorner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Orange_InCorner_03_C": {
+    "name": "Inner Corner Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Orange_InCorner_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Orange_OutCorner_01_C": {
+    "name": "Outer Corner Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Orange_OutCorner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Orange_OutCorner_02_C": {
+    "name": "Outer Corner Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Orange_OutCorner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Orange_OutCorner_03_C": {
+    "name": "Outer Corner Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Orange_OutCorner_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Window_01_C": {
+    "name": "Flat Roof",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Window_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Window_02_C": {
+    "name": "Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Window_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Window_03_C": {
+    "name": "Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Window_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Window_04_C": {
+    "name": "Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Window_04_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Window_InCorner_01_C": {
+    "name": "Inner Corner Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Window_InCorner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Window_InCorner_02_C": {
+    "name": "Inner Corner Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Window_InCorner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Window_InCorner_03_C": {
+    "name": "Inner Corner Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Window_InCorner_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Window_OutCorner_01_C": {
+    "name": "Outer Corner Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Window_OutCorner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Window_OutCorner_02_C": {
+    "name": "Outer Corner Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Window_OutCorner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Window_OutCorner_03_C": {
+    "name": "Outer Corner Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Window_OutCorner_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_A_01_C": {
+    "name": "Flat Roof",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_A_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_A_02_C": {
+    "name": "Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_A_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_A_03_C": {
+    "name": "Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_A_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_A_04_C": {
+    "name": "Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_A_04_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Metal_InCorner_01_C": {
+    "name": "Inner Corner Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Metal_InCorner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Metal_InCorner_02_C": {
+    "name": "Inner Corner Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Metal_InCorner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Metal_InCorner_03_C": {
+    "name": "Inner Corner Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Metal_InCorner_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Metal_OutCorner_01_C": {
+    "name": "Outer Corner Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Metal_OutCorner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Metal_OutCorner_02_C": {
+    "name": "Outer Corner Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Metal_OutCorner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Metal_OutCorner_03_C": {
+    "name": "Outer Corner Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Metal_OutCorner_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Tar_01_C": {
+    "name": "Flat Roof",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Tar_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Tar_02_C": {
+    "name": "Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Tar_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Tar_03_C": {
+    "name": "Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Tar_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Tar_04_C": {
+    "name": "Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Tar_04_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Tar_InCorner_01_C": {
+    "name": "Inner Corner Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Tar_InCorner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Tar_InCorner_02_C": {
+    "name": "Inner Corner Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Tar_InCorner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Tar_InCorner_03_C": {
+    "name": "Inner Corner Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Tar_InCorner_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Tar_OutCorner_01_C": {
+    "name": "Outer Corner Roof (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Tar_OutCorner_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Tar_OutCorner_02_C": {
+    "name": "Outer Corner Roof (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Tar_OutCorner_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Roof_Tar_OutCorner_03_C": {
+    "name": "Outer Corner Roof (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Roof_Tar_OutCorner_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ElevatorFloorStop_C": {
+    "name": "Elevator Floor Stop",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_ModularFrame_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Motor_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ElevatorFloorStop_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Elevator_C": {
+    "name": "Personnel Elevator",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_Silica_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Elevator_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PipelineMK2_NoIndicator_C": {
+    "name": "Clean Pipeline Mk.2",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PipelineMK2_NoIndicator_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pipeline_NoIndicator_C": {
+    "name": "Clean Pipeline Mk.1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Pipeline_NoIndicator_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StorageMedkit_C": {
+    "name": "Medical Storage Box",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StorageMedkit_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_LightsControlPanel_C": {
+    "name": "Light Control Panel",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cable_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_CircuitBoardHighSpeed_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_LightsControlPanel_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StandaloneWidgetSign_Small_C": {
+    "name": "Label Sign (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StandaloneWidgetSign_Small_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StandaloneWidgetSign_SmallVeryWide_C": {
+    "name": "Label Sign (4 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StandaloneWidgetSign_SmallVeryWide_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StandaloneWidgetSign_SmallWide_C": {
+    "name": "Label Sign (3 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StandaloneWidgetSign_SmallWide_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StandaloneWidgetSign_Square_Tiny_C": {
+    "name": "Square Sign (0.5 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StandaloneWidgetSign_Square_Tiny_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FoundationPassthrough_Hypertube_C": {
+    "name": "Hypertube Floor Hole",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FoundationPassthrough_Hypertube_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StorageHazard_C": {
+    "name": "Hazard Storage Box",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 6
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StorageHazard_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_GoldenCart_C": {
+    "name": "Golden Factory Cart™",
+    "duration": 20,
+    "ingredients": [
+      {
+        "item": "Desc_GoldIngot_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_Rotor_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GolfCartGold_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Window_8x4_05_C": {
+    "name": "Angled Frame Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Window_8x4_05_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Window_8x4_06_C": {
+    "name": "Honeycomb Frame Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Window_8x4_06_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Window_8x4_07_C": {
+    "name": "Triple Frame Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Window_8x4_07_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Window_Thin_8x4_01_C": {
+    "name": "Full Frame Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Window_Thin_8x4_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wall_Window_Thin_8x4_02_C": {
+    "name": "Hex Frame Window",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wall_Window_Thin_8x4_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pillar_Small_Frame_C": {
+    "name": "Small Frame Pillar",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Pillar_Small_Frame_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PillarMiddle_Frame_C": {
+    "name": "Big Frame Pillar",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PillarMiddle_Frame_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ChainLinkFence_C": {
+    "name": "Construction Fence",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ChainLinkFence_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_TarpFence_C": {
+    "name": "Tarp Construction Fence",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_TarpFence_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Barrier_Low_01_C": {
+    "name": "Low Barrier",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Barrier_Low_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Barrier_Tall_01_C": {
+    "name": "High Barrier",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Barrier_Tall_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Barrier_Corner_C": {
+    "name": "Corner Road Barrier",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Barrier_Corner_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Concrete_Barrier_01_C": {
+    "name": "Road Barrier",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Concrete_Barrier_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StandaloneWidgetSign_Medium_C": {
+    "name": "Display Sign",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StandaloneWidgetSign_Medium_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StandaloneWidgetSign_Portrait_C": {
+    "name": "Portrait Sign",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StandaloneWidgetSign_Portrait_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StandaloneWidgetSign_Square_C": {
+    "name": "Square Sign (2 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StandaloneWidgetSign_Square_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StandaloneWidgetSign_Square_Small_C": {
+    "name": "Square Sign (1 m)",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StandaloneWidgetSign_Square_Small_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorWallHole_C": {
+    "name": "Conveyor Wall Hole",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorWallHole_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConveyorMonitor_C": {
+    "name": "Conveyor Throughput Monitor",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_QuartzCrystal_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConveyorMonitor_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_FoundationPassthrough_Lift_C": {
+    "name": "Conveyor Lift Floor Hole",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_FoundationPassthrough_Lift_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pillar_Small_Concrete_C": {
+    "name": "Small Concrete Pillar",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Pillar_Small_Concrete_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PillarMiddle_Concrete_C": {
+    "name": "Big Concrete Pillar",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_PillarMiddle_Concrete_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Catwalk_Cross_C": {
+    "name": "Catwalk Intersection",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CatwalkCross_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Catwalk_Ramp_C": {
+    "name": "Catwalk Ramp",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CatwalkRamp_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Catwalk_Stairs_C": {
+    "name": "Catwalk Stairs",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CatwalkStairs_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Catwalk_Straight_C": {
+    "name": "Straight Catwalk",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CatwalkStraight_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Catwalk_T_C": {
+    "name": "Catwalk T-Junction",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CatwalkT_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Catwalk_Turn_C": {
+    "name": "Catwalk Corner",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CatwalkTurn_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StandaloneWidgetSign_Huge_C": {
+    "name": "Large Billboard",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 12
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 20
+      },
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 5
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StandaloneWidgetSign_Huge_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StandaloneWidgetSign_Large_C": {
+    "name": "Small Billboard",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlateReinforced_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_CopperSheet_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_CrystalOscillator_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StandaloneWidgetSign_Large_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Beam_Cable_C": {
+    "name": "Braided Cable",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Beam_Cable_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Beam_Cable_Cluster_C": {
+    "name": "Braided Cable Cluster",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Beam_Cable_Cluster_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Beam_Connector_C": {
+    "name": "Beam Connector",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Beam_Connector_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Beam_Connector_Double_C": {
+    "name": "Double Beam Connector",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Beam_Connector_Double_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Beam_Support_C": {
+    "name": "Beam Support",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Beam_Support_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Beam_Concrete_C": {
+    "name": "Round Concrete Beam",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Beam_Concrete_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Beam_H_C": {
+    "name": "H-Beam",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Beam_H_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Beam_Shelf_C": {
+    "name": "Shelf Beam",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Beam_Shelf_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Beam_C": {
+    "name": "Metal Beam",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Beam_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Beam_Painted_C": {
+    "name": "Painted Beam",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Beam_Painted_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_GeneratorBiomass_Automated_C": {
+    "name": "Biomass Burner",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 15
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 25
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GeneratorBiomass_Automated_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SpaceElevator_C": {
+    "name": "Space Elevator",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 500
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 250
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 400
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 1500
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SpaceElevator_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Biomass_Leaves_C": {
+    "name": "Biomass (Leaves)",
+    "duration": 5,
+    "ingredients": [
+      {
+        "item": "Desc_Leaves_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GenericBiomass_C",
+        "amount": 5
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Biomass_Wood_C": {
+    "name": "Biomass (Wood)",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_Wood_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_GenericBiomass_C",
+        "amount": 20
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_MinerMk1_C": {
+    "name": "Miner Mk.1",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "BP_ItemDescriptorPortableMiner_C",
+        "amount": 1
+      },
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_Cement_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_MinerMk1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_StorageContainerMk1_C": {
+    "name": "Storage Container",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 10
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 10
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_StorageContainerMk1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_IronPlateReinforced_C": {
+    "name": "Reinforced Iron Plate",
+    "duration": 12,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 12
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_ConstructorMk1_C": {
+    "name": "Constructor",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlateReinforced_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_Cable_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_ConstructorMk1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Concrete_C": {
+    "name": "Concrete",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_Stone_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Screw_C": {
+    "name": "Screws",
+    "duration": 6,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_IronScrew_C",
+        "amount": 4
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SmelterBasicMk1_C": {
+    "name": "Smelter",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 5
+      },
+      {
+        "item": "Desc_Wire_C",
+        "amount": 8
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_SmelterMk1_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Cable_C": {
+    "name": "Cable",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_Wire_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Cable_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Wire_C": {
+    "name": "Wire",
+    "duration": 4,
+    "ingredients": [
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Wire_C",
+        "amount": 2
+      }
+    ],
+    "producedIn": [
+      "Desc_ConstructorMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_IngotCopper_C": {
+    "name": "Copper Ingot",
+    "duration": 2,
+    "ingredients": [
+      {
+        "item": "Desc_OreCopper_C",
+        "amount": 1
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_CopperIngot_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_SmelterMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Workshop_C": {
+    "name": "Equipment Workshop",
+    "duration": 1,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Workshop_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PortableMiner_C": {
+    "name": "Portable Miner",
+    "duration": 40,
+    "ingredients": [
+      {
+        "item": "Desc_IronPlate_C",
+        "amount": 2
+      },
+      {
+        "item": "Desc_IronRod_C",
+        "amount": 4
+      }
+    ],
+    "products": [
+      {
+        "item": "BP_ItemDescriptorPortableMiner_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Fireworks_01_C": {
+    "name": "Sweet Fireworks",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_XmasBranch_C",
+        "amount": 6
+      },
+      {
+        "item": "Desc_CandyCane_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Fireworks_Projectile_01_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Fireworks_02_C": {
+    "name": "Fancy Fireworks",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_XmasBranch_C",
+        "amount": 4
+      },
+      {
+        "item": "Desc_XmasBow_C",
+        "amount": 3
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Fireworks_Projectile_02_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Fireworks_03_C": {
+    "name": "Sparkly Fireworks",
+    "duration": 24,
+    "ingredients": [
+      {
+        "item": "Desc_XmasBranch_C",
+        "amount": 3
+      },
+      {
+        "item": "Desc_Snow_C",
+        "amount": 2
+      }
+    ],
+    "products": [
+      {
+        "item": "Desc_Fireworks_Projectile_03_C",
+        "amount": 1
+      }
+    ],
+    "producedIn": [
+      "Desc_AssemblerMk1_C"
+    ],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Remover_Arrows_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Remover_Icons_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Remover_Lines_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Remover_Numbers_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Remover_Paths_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Remover_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Remover_Zones_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot17_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Custom_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_ProjectAssembly_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot0_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot1_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot10_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot11_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot12_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot13_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot14_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot15_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot16_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot18_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot19_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot2_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot20_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot3_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot4_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot5_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot6_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot7_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot8_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Slot9_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Material_Foundation_Concrete_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Material_Foundation_GripMetal_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Material_Foundation_PolishedConcrete_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [
+      {
+        "item": "Desc_Plastic_C",
+        "amount": 2
+      }
+    ],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Material_Foundation_Asphalt_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Material_Wall_Concrete_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Swatch_Concrete_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Material_Wall_Steel_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Material_Roof_Glass_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [
+      {
+        "item": "Desc_Silica_C",
+        "amount": 2
+      }
+    ],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Material_Roof_Metal_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [
+      {
+        "item": "Desc_SteelPlate_C",
+        "amount": 2
+      }
+    ],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Material_Roof_Tar_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [
+      {
+        "item": "Desc_Cement_C",
+        "amount": 2
+      }
+    ],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_ZoneFull_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_ZoneHalf_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_ZoneLine_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_ZoneQuarter_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PaintFinish_UnPainted_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_PathCart_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_PathCorner_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_PathCross_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_PathPioneer_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_PathSplit_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_PathStraight_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_PathZebra_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Number0_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Number1_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Number2_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Number3_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Number4_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Number5_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Number6_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Number7_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Number8_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Number9_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_Cart_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_Explorer_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_Parking_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_Tractor_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_Truck_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_NO_Cart_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_NO_Parking_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_FullZebra_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_Factory_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_Liquid_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_Nuclear_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_Pioneer_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_Power_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_StopCross_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_Icon_Storage_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_NO_Pioneer_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_LineCentre_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_LineCentreCorner_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_LineCross_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_LineDouble_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_LineSide_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_LineSideCorner_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_LineSplit_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_DottedCentre_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_DottedCentreCorner_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_DottedCross_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_DottedDouble_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_DottedSide_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_DottedSideCorner_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_DottedSplit_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PaintFinish_Copper_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PaintFinish_Chrome_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PaintFinish_Caterium_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_PaintFinish_CarbonSteel_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_ArrowBack_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_ArrowLeft_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_ArrowRight_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_ArrowStraight_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_NO_ArrowLeft_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_NO_ArrowRight_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_Pattern_NO_ArrowStraight_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SkinFicsmas_Premium_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [
+      {
+        "item": "Desc_XmasStar_C",
+        "amount": 1
+      }
+    ],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SkinRemover_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  },
+  "Recipe_SkinFicsmas_Default_C": {
+    "name": "N/A",
+    "duration": 0,
+    "ingredients": [
+      {
+        "item": "Desc_Gift_C",
+        "amount": 1
+      }
+    ],
+    "products": [],
+    "producedIn": [],
+    "alternate": false,
+    "minPower": null,
+    "maxPower": null
+  }
+}

--- a/scripts/update_data.py
+++ b/scripts/update_data.py
@@ -1,0 +1,152 @@
+import json
+import re
+import requests
+
+BASE_URL = 'https://satisfactory.wiki.gg/api.php'
+
+TEMPLATES = {
+    'items': 'Template:DocsItems.json',
+    'buildings': 'Template:DocsBuildings.json',
+    'recipes': 'Template:DocsRecipes.json',
+}
+
+
+def fetch_template(name: str) -> dict:
+    params = {
+        'action': 'parse',
+        'page': TEMPLATES[name],
+        'prop': 'wikitext',
+        'format': 'json'
+    }
+    r = requests.get(BASE_URL, params=params, timeout=30)
+    r.raise_for_status()
+    data = r.json()
+    wikitext = data['parse']['wikitext']['*']
+    return json.loads(wikitext)
+
+
+def save_json(data: dict, path: str) -> None:
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def main() -> None:
+    items = fetch_template('items')
+    buildings = fetch_template('buildings')
+    recipes = fetch_template('recipes')
+
+    # gather building usage from recipes to filter only production buildings
+    produced_in: set[str] = set()
+    variable_power: dict[str, dict[str, float]] = {}
+    port_counts: dict[str, dict[str, int]] = {}
+    for data in recipes.values():
+        info = data[0]
+        for b in info.get('producedIn', []):
+            produced_in.add(b)
+            min_p = info.get('minPower')
+            max_p = info.get('maxPower')
+            if min_p is not None or max_p is not None:
+                vp = variable_power.setdefault(b, {"minPower": float("inf"), "maxPower": 0})
+                if min_p is not None and min_p < vp["minPower"]:
+                    vp["minPower"] = min_p
+                if max_p is not None and max_p > vp["maxPower"]:
+                    vp["maxPower"] = max_p
+            cnt = port_counts.setdefault(b, {"inputs": 0, "outputs": 0})
+            cnt["inputs"] = max(cnt["inputs"], len(info.get("ingredients", [])))
+            cnt["outputs"] = max(cnt["outputs"], len(info.get("products", [])))
+
+    # clean items: only keep basic fields
+    clean_items = {}
+    for k, v in items.items():
+        info = v[0]
+        clean_items[k] = {
+            "name": info["name"],
+            "stackSize": info.get("stackSize"),
+            "energy": info.get("energy"),
+            "form": info.get("form"),
+        }
+    save_json(clean_items, 'data/items.json')
+
+    # helper to parse throughput from description
+    def parse_throughput(desc: str) -> int | None:
+        m = re.search(r"(?:up to|Capacity:)\s*([0-9]+)[^0-9]*(?:resources|m³).*per minute", desc)
+        if m:
+            return int(m.group(1))
+        return None
+
+    belts_pipes: dict[str, dict] = {}
+    power_plants: dict[str, dict] = {}
+    prod_buildings: dict[str, dict] = {}
+
+    extra_production = {
+        "Desc_MinerMk1_C", "Desc_MinerMk2_C", "Desc_MinerMk3_C",
+        "Desc_WaterPump_C", "Desc_OilPump_C", "Desc_FrackingSmasher_C"
+    }
+    for cls, data in buildings.items():
+        info = data[0]
+        name = info["name"]
+
+        # logistics buildings (only belts and pipelines)
+        if any(key in cls for key in ["ConveyorBelt", "Pipeline"]):
+            if any(s in cls for s in ["Lift", "Pump", "Junction", "Valve", "Support", "Wall", "Attachment", "Crossing", "Pole", "Stackable", "NoIndicator"]):
+                continue
+            entry = {"name": name}
+            tp = parse_throughput(info.get("description", ""))
+            if tp:
+                entry["throughput"] = tp
+            belts_pipes[cls] = entry
+            continue
+
+        # power plants
+        if info.get("powerGenerated", 0) > 0:
+            if info.get("isVehicle"):
+                continue
+            power_plants[cls] = {
+                "name": name,
+                "powerGenerated": info["powerGenerated"],
+                "somersloopSlots": info.get("somersloopSlots", 0),
+                "overclockable": info.get("overclockable", False),
+                "burnsFuel": info.get("burnsFuel", []),
+                "supplementPerMinute": info.get("supplementPerMinute", 0),
+            }
+            continue
+
+        # production buildings
+        if cls in produced_in or cls in extra_production:
+            entry = {
+                "name": name,
+                "powerUsage": info.get("powerUsage", 0),
+                "somersloopSlots": info.get("somersloopSlots", 0),
+                "overclockable": info.get("overclockable", False),
+                "inputs": port_counts.get(cls, {"inputs": 0})["inputs"],
+                "outputs": port_counts.get(cls, {"outputs": 1})["outputs"],
+            }
+            if cls in variable_power:
+                vp = variable_power[cls]
+                entry["minPower"] = None if vp["minPower"] == float("inf") else vp["minPower"]
+                entry["maxPower"] = vp["maxPower"]
+            prod_buildings[cls] = entry
+
+    # clean recipes: keep only needed fields
+    clean_recipes = {}
+    for cls, data in recipes.items():
+        info = data[0]
+        clean_recipes[cls] = {
+            "name": info["name"],
+            "duration": info["duration"],
+            "ingredients": info.get("ingredients", []),
+            "products": info.get("products", []),
+            "producedIn": info.get("producedIn", []),
+            "alternate": info.get("alternate", False),
+            "minPower": info.get("minPower"),
+            "maxPower": info.get("maxPower"),
+        }
+
+    save_json(clean_recipes, 'data/recipes.json')
+    save_json(prod_buildings, 'data/buildings.json')
+    save_json(belts_pipes, 'data/belts_pipes.json')
+    save_json(power_plants, 'data/power_plants.json')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- purge non-production buildings like pumps and stations
- skip lifts and pumps when generating belt data
- infer building input/output port counts from recipes
- record ports and keep only production buildings in `buildings.json`
- document trimmed datasets in README
- remove leftover clean pipelines and vehicles

## Testing
- `python3 -m py_compile satisfactory_flow_gui.py scripts/update_data.py`
- `python3 scripts/update_data.py`


------
https://chatgpt.com/codex/tasks/task_e_686f2c2f6d80832bb63dcfd478ebefd5