### PR TITLE
Add console fallback and AI testing guide

### DIFF
--- a/AGENT_TESTING.md
+++ b/AGENT_TESTING.md
@@ -1,0 +1,41 @@
+# AI Agent Testing Guide
+
+This document describes how an automated agent can verify the basic
+functionality of **SatisfactoryFlow**.
+
+## Setup
+1. Ensure Python 3.10 or newer is installed.
+2. Install dependencies:
+   ```bash
+   pip install networkx matplotlib requests
+   ```
+3. (Optional) Run `python3 scripts/update_data.py` if you wish to refresh the
+   data files from the Satisfactory wiki.
+
+## Running the Application
+Invoke the launcher script:
+```bash
+python3 satisfactory_flow_gui.py
+```
+- If a GUI display is available, a window will open.
+- When no display is detected, the application automatically falls back to a
+  console interface.
+
+## Basic Manual Test Steps
+1. **Add Node**
+   - In the GUI use the `Add Node` button, or in console type `add`.
+   - Provide sample data and confirm the node appears in the list.
+2. **Save Workspace**
+   - Trigger the *Save* action (`Ctrl+S`, the GUI button or `save` command).
+   - Verify that `workspace.json` is created or updated.
+3. **Load Workspace**
+   - Restart the application and check that previously created nodes are loaded.
+4. **Build Graph** (GUI only)
+   - Click *Show Graph* and ensure a matplotlib window renders a graph of node
+     connections.
+5. **Delete Node**
+   - Remove a node using the *Delete* action or the `delete` command and confirm
+     it no longer appears.
+
+These steps provide a minimal smoke test for the application in both GUI and
+console modes.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Run the tool with:
 python3 satisfactory_flow_gui.py
 ```
 
+If a graphical display cannot be detected the launcher will automatically
+start a simple console interface instead.
+
 The GUI and models are now organized under the `satisfactory_flow` package.
 `satisfactory_flow_gui.py` simply launches the app.
 

--- a/satisfactory_flow/console.py
+++ b/satisfactory_flow/console.py
@@ -1,0 +1,106 @@
+import json
+import os
+from typing import Dict, List
+
+from .models import Node
+
+WORKSPACE_FILE = "workspace.json"
+
+
+def parse_lines(text: str) -> Dict[str, float]:
+    result: Dict[str, float] = {}
+    for line in text.strip().splitlines():
+        if not line.strip():
+            continue
+        for part in line.split(','):
+            if ':' in part:
+                item, qty = part.split(':', 1)
+                try:
+                    result[item.strip()] = float(qty)
+                except ValueError:
+                    pass
+    return result
+
+
+class ConsoleApp:
+    def __init__(self) -> None:
+        self.nodes: List[Node] = []
+        self.load_workspace()
+
+    def load_workspace(self) -> None:
+        if os.path.exists(WORKSPACE_FILE):
+            with open(WORKSPACE_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.nodes = [Node.from_dict(d) for d in data]
+
+    def save_workspace(self) -> None:
+        data = [n.to_dict() for n in self.nodes]
+        with open(WORKSPACE_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        print("Workspace saved")
+
+    def list_nodes(self) -> None:
+        if not self.nodes:
+            print("No nodes defined")
+            return
+        for idx, node in enumerate(self.nodes):
+            print(f"{idx}: {node.name} | Power {node.power_usage():.2f} MW")
+
+    def add_node(self) -> None:
+        name = input("Name: ").strip()
+        base_power = float(input("Base Power: ").strip() or 0)
+        print("Enter inputs (item:qty, comma separated per line). End with empty line")
+        lines = []
+        while True:
+            ln = input()
+            if not ln:
+                break
+            lines.append(ln)
+        inputs = parse_lines("\n".join(lines))
+        print("Enter outputs (item:qty, comma separated per line). End with empty line")
+        lines = []
+        while True:
+            ln = input()
+            if not ln:
+                break
+            lines.append(ln)
+        outputs = parse_lines("\n".join(lines))
+        clock = float(input("Clock Speed % (default 100): ").strip() or 100)
+        shards = int(input("Power Shards (default 0): ").strip() or 0)
+        filled = int(input("Filled Slots (default 0): ").strip() or 0)
+        total = int(input("Total Slots (default 0): ").strip() or 0)
+        node = Node(name, base_power, inputs, outputs, clock, shards, filled, total)
+        self.nodes.append(node)
+        print("Node added")
+
+    def delete_node(self) -> None:
+        idx = int(input("Index to delete: "))
+        if 0 <= idx < len(self.nodes):
+            del self.nodes[idx]
+            print("Node deleted")
+        else:
+            print("Invalid index")
+
+    def run(self) -> None:
+        print("Satisfactory Flow Console")
+        while True:
+            cmd = input("Command (help for list): ").strip().lower()
+            if cmd in {"quit", "exit"}:
+                self.save_workspace()
+                break
+            elif cmd == "help":
+                print("Commands: list, add, delete, save, load, quit")
+            elif cmd == "list":
+                self.list_nodes()
+            elif cmd == "add":
+                self.add_node()
+            elif cmd == "delete":
+                self.delete_node()
+            elif cmd == "save":
+                self.save_workspace()
+            elif cmd == "load":
+                self.load_workspace()
+                print("Workspace loaded")
+            else:
+                print("Unknown command")
+

--- a/satisfactory_flow_gui.py
+++ b/satisfactory_flow_gui.py
@@ -1,5 +1,23 @@
+import os
+import tkinter as tk
 from satisfactory_flow.gui import App
+from satisfactory_flow.console import ConsoleApp
+
+
+def has_display() -> bool:
+    if os.name == "nt":
+        return True
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
 
 if __name__ == "__main__":
-    app = App()
-    app.mainloop()
+    if has_display():
+        try:
+            app = App()
+            app.mainloop()
+        except tk.TclError:
+            print("No display available, falling back to console mode")
+            ConsoleApp().run()
+    else:
+        print("No display detected, running in console mode")
+        ConsoleApp().run()


### PR DESCRIPTION
## Summary
- add `ConsoleApp` CLI for headless environments
- automatically fall back to the console if no display is detected
- mention console mode in the README
- provide AI Agent Testing Guide

## Testing
- `python3 -m py_compile satisfactory_flow/__init__.py satisfactory_flow/gui.py satisfactory_flow/models.py satisfactory_flow/console.py satisfactory_flow_gui.py scripts/update_data.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f3b48285c832bba040a37d4f7206e