### PR TITLE
Add recipe disable feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features
 - Clock speeds are stored with four decimal places of precision.
 - Optional Somersloop style power multiplier using filled and total slot counts.
 - Save and load a workspace automatically (`workspace.json`).
+- Toggle unavailable alternate recipes via the **Recipes** button (saved in the workspace).
 - Visualize node connections with a simple graph using NetworkX and Matplotlib.
 - Shortcut **Ctrl+S** or the *Save* button to store the current workspace.
 


### PR DESCRIPTION
## Summary
- manage alternate recipes with new check box dialog
- persist disabled recipes in workspace file
- expose recipe selection in console app
- document feature in README

## Testing
- `python3 -m py_compile satisfactory_flow/*.py satisfactory_flow_gui.py`
- `pip install networkx matplotlib requests`
- `python3 satisfactory_flow_gui.py <<'EOF'
help
recipes

quit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_686f4cf3618c832b8d502f6ebf980ac9