### PR TITLE
Add power usage calculation to optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Features
 - Support for clock speeds from 0% to 250% with the Satisfactory overclocking power formula. The
   allowed maximum clock speed is automatically limited to `100% + 50% × shards` (capped at 250%).
 - Clock speeds are stored with four decimal places of precision.
-- Optional Somersloop style power multiplier using filled and total slot counts.
+- Optional Somersloop style multiplier using filled and total slots that affects
+  both production and power usage.
 - Save and load a workspace automatically (`workspace.json`).
 - Toggle unavailable alternate recipes via the **Recipes** button (saved in the workspace).
 - Visualize node connections with a simple graph using NetworkX and Matplotlib.
@@ -37,3 +38,13 @@ The `data/` directory contains JSON files generated from the [Official Satisfact
 - `power_plants.json` – buildings that generate power
 
 Run `python3 scripts/update_data.py` to refresh these files from the wiki.
+
+## Command line optimizer
+
+`scripts/optimize_production.py` calculates the minimal number of buildings needed to reach a target production rate given limits on power shards and Somersloops. It prints a summary including the total power usage and can display a simple graph of the result.
+
+Example:
+
+```bash
+PYTHONPATH=. python3 scripts/optimize_production.py 430 7 0 --base-power 20
+```

--- a/satisfactory_flow/gui.py
+++ b/satisfactory_flow/gui.py
@@ -285,7 +285,14 @@ class AutoDialog(simpledialog.Dialog):
         item_name = self.cb.get()
         item_id = self.name_map[item_name]
         rate = float(self.rate.get())
-        self.result = {'item_id': item_id, 'rate': rate}
+        loops = int(self.somers.get())
+        shards = int(self.shards.get())
+        self.result = {
+            'item_id': item_id,
+            'rate': rate,
+            'max_loops': loops,
+            'max_shards': shards,
+        }
 
 
 class RecipeDialog(simpledialog.Dialog):

--- a/satisfactory_flow/models.py
+++ b/satisfactory_flow/models.py
@@ -32,7 +32,7 @@ class Node:
         return usage
 
     def production_factor(self) -> float:
-        return self.clock / 100.0
+        return (self.clock / 100.0) * self.power_multiplier()
 
     def to_dict(self) -> Dict:
         return {

--- a/satisfactory_flow/optimizer.py
+++ b/satisfactory_flow/optimizer.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+import networkx as nx
+import matplotlib.pyplot as plt
+
+
+@dataclass
+class BuildingPlan:
+    shards: int
+    loops: int
+    clock: float
+    production: float
+
+
+def building_power(clock: float, base_power: float, loops: int, slots: int = 4) -> float:
+    """Return power usage for a single building with given settings."""
+    return base_power * loops_multiplier(loops, slots) * ((clock / 100.0) ** 1.321928)
+
+
+def plan_power(plan: List[BuildingPlan], base_power: float, slots: int = 4) -> float:
+    """Total power usage of an entire building plan."""
+    return sum(building_power(p.clock, base_power, p.loops, slots) for p in plan)
+
+
+def loops_multiplier(loops: int, slots: int = 4) -> float:
+    """Return production multiplier from somersloops."""
+    if slots <= 0:
+        return 1.0
+    return (1 + loops / slots) ** 2
+
+
+def max_clock_for_shards(shards: int) -> float:
+    """Maximum clock speed allowed for given shard count."""
+    return min(250.0, 100.0 + shards * 50.0)
+
+
+def search_plan(target: float, max_shards: int, max_loops: int,
+                slots: int = 4, max_shards_per_building: int = 3) -> List[BuildingPlan]:
+    """Find a combination of buildings meeting the target production.
+
+    The target is expressed as a multiple of base production (e.g. ``4.3`` for
+    430%). Shards and loops are integers. Buildings may be partially
+    underclocked to exactly hit the target.
+    """
+    best: tuple[int, int, int, List[BuildingPlan]] | None = None
+
+    combos = []
+    for s in range(0, max_shards_per_building + 1):
+        for l in range(0, slots + 1):
+            cap = max_clock_for_shards(s) / 100.0 * loops_multiplier(l, slots)
+            combos.append((cap, s, l))
+    combos.sort(reverse=True)
+
+    def plan_key(p: List[BuildingPlan]) -> tuple[int, int, int]:
+        return (len(p), sum(b.shards for b in p), sum(b.loops for b in p))
+
+    def backtrack(remaining: float, shards_left: int, loops_left: int, plan: List[BuildingPlan]):
+        nonlocal best
+        if remaining <= 0:
+            key = plan_key(plan)
+            if best is None or key < best[:3]:
+                best = (*key, list(plan))
+            return
+        if best is not None and len(plan) >= best[0]:
+            return
+        for cap, s, l in combos:
+            if s <= shards_left and l <= loops_left:
+                plan.append(BuildingPlan(shards=s, loops=l, clock=max_clock_for_shards(s), production=cap))
+                backtrack(remaining - cap, shards_left - s, loops_left - l, plan)
+                plan.pop()
+
+    backtrack(target, max_shards, max_loops, [])
+    if best is None:
+        raise ValueError("Target cannot be met with given shards and loops")
+
+    plan = best[3]
+    # Adjust final building to hit the target exactly
+    total = sum(p.production for p in plan)
+    if total > target:
+        diff = total - target
+        last = plan[-1]
+        new_prod = last.production - diff
+        new_clock = (new_prod / loops_multiplier(last.loops, slots)) * 100.0
+        plan[-1] = BuildingPlan(shards=last.shards, loops=last.loops,
+                                clock=new_clock, production=new_prod)
+    return plan
+
+
+def visualize_plan(plan: List[BuildingPlan]) -> None:
+    """Show a simple graph of the building plan."""
+    G = nx.DiGraph()
+    for i, p in enumerate(plan, 1):
+        label = f"B{i}\nShards:{p.shards}\nLoops:{p.loops}\nClock:{p.clock:.1f}%"
+        G.add_node(f"B{i}", label=label)
+        G.add_edge(f"B{i}", "Output")
+    G.add_node("Output", label="Total")
+    pos = nx.spring_layout(G)
+    nx.draw(G, pos, with_labels=True, labels=nx.get_node_attributes(G, 'label'), node_color='lightblue')
+    plt.show()
+

--- a/scripts/optimize_production.py
+++ b/scripts/optimize_production.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Calculate optimal building plan for a given production target."""
+from __future__ import annotations
+
+import argparse
+from satisfactory_flow.optimizer import (
+    search_plan,
+    visualize_plan,
+    plan_power,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Production optimizer")
+    parser.add_argument("target", type=float, help="Target production percentage (e.g. 430 for 430%)")
+    parser.add_argument("shards", type=int, help="Maximum total power shards available")
+    parser.add_argument("loops", type=int, help="Maximum total somersloops available")
+    parser.add_argument("--base-power", type=float, default=1.0,
+                        help="Base power usage per building (MW)")
+    parser.add_argument("--no-graph", action="store_true", help="Do not display graph")
+    args = parser.parse_args()
+
+    target_factor = args.target / 100.0
+    plan = search_plan(target_factor, args.shards, args.loops)
+    print("Building plan:")
+    for idx, p in enumerate(plan, 1):
+        boost = p.production * 100 - 100
+        print(f"Building {idx}: {p.clock:.1f}% clock, {p.shards} shards, {p.loops} loops -> {p.production*100:.1f}%")
+    total = sum(p.production for p in plan) * 100
+    print(f"Total production: {total:.1f}%")
+    power = plan_power(plan, args.base_power)
+    print(f"Total power usage: {power:.2f} MW")
+    if not args.no_graph:
+        visualize_plan(plan)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- include somersloop multiplier in production calculation
- expose total power usage in the optimizer
- new `--base-power` option for `optimize_production.py`
- note power usage and multiplier details in README
- store somersloop and shard inputs from Auto Build dialog

## Testing
- `python3 -m py_compile satisfactory_flow/optimizer.py scripts/optimize_production.py`
- `PYTHONPATH=. python3 scripts/optimize_production.py 430 7 0 --no-graph --base-power 20`

------
https://chatgpt.com/codex/tasks/task_e_686f556f1980832b892c0ce050cc8d17