### PR TITLE
Fix throughput calc and show clock in graph

### DIFF
--- a/satisfactory_flow/auto.py
+++ b/satisfactory_flow/auto.py
@@ -82,13 +82,13 @@ def _gen_nodes(item_id: str, rate: float, nodes: List[Node], seen: set[str] | No
     machines = rate / per_machine if per_machine > 0 else 1.0
     if machines < 1:
         machines = 1.0
-    total_power = base_power * machines
 
     node = Node(
         name=f"{building_name} ({recipe['name']})",
-        base_power=total_power,
+        base_power=base_power,
         inputs={},
         outputs={item_name: rate},
+        count=machines,
     )
     nodes.append(node)
 

--- a/satisfactory_flow/gui.py
+++ b/satisfactory_flow/gui.py
@@ -88,7 +88,8 @@ class App(tk.Tk):
     def build_graph(self) -> nx.DiGraph:
         G = nx.DiGraph()
         for idx, node in enumerate(self.nodes):
-            G.add_node(idx, label=node.name)
+            label = f"{node.name}\n{node.clock:.1f}%"
+            G.add_node(idx, label=label)
         for src_idx, src in enumerate(self.nodes):
             for item in src.outputs:
                 for dst_idx, dst in enumerate(self.nodes):

--- a/satisfactory_flow/models.py
+++ b/satisfactory_flow/models.py
@@ -11,6 +11,7 @@ class Node:
     shards: int = 0
     filled_slots: int = 0
     total_slots: int = 0
+    count: float = 1.0
 
     def __post_init__(self) -> None:
         self.clock = round(max(0.0, min(self.clock, self.max_clock())), 4)
@@ -26,13 +27,13 @@ class Node:
         return (1 + (self.filled_slots / self.total_slots)) ** 2
 
     def power_usage(self) -> float:
-        base = self.base_power
+        base = self.base_power * self.count
         multiplier = self.power_multiplier()
         usage = base * multiplier * ((self.clock / 100) ** 1.321928)
         return usage
 
     def production_factor(self) -> float:
-        return (self.clock / 100.0) * self.power_multiplier()
+        return (self.clock / 100.0) * self.power_multiplier() * self.count
 
     def to_dict(self) -> Dict:
         return {
@@ -44,6 +45,7 @@ class Node:
             "shards": self.shards,
             "filled_slots": self.filled_slots,
             "total_slots": self.total_slots,
+            "count": self.count,
         }
 
     @staticmethod
@@ -57,5 +59,6 @@ class Node:
             shards=d.get("shards", 0),
             filled_slots=d.get("filled_slots", 0),
             total_slots=d.get("total_slots", 0),
+            count=d.get("count", 1.0),
         )
 


### PR DESCRIPTION
## Summary
- track how many buildings a node represents
- compute power usage based on building count
- show the building clock percentage in graph nodes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install networkx matplotlib requests`
- `PYTHONPATH=. python3 scripts/optimize_production.py 430 7 0 --base-power 20 --no-graph`

------
https://chatgpt.com/codex/tasks/task_e_686f5bdc3db8832bb29f371270cf1702