### PR TITLE
Adjust graph labels for sources

### DIFF
--- a/satisfactory_flow/auto.py
+++ b/satisfactory_flow/auto.py
@@ -160,6 +160,12 @@ def _merge_nodes(nodes: List[Node]) -> List[Node]:
     for key, node in merged.items():
         out_name, out_rate = next(iter(node.outputs.items()))
         pm = per_machine.get(key, 0.0)
+        if key.startswith("Source"):
+            # Keep a single source node regardless of the combined rate
+            node.count = 1.0
+            node.clock = 100.0
+            result.append(node)
+            continue
         if pm <= 0:
             # Source or loop; assume rate per machine equals first node rate
             pm = out_rate

--- a/satisfactory_flow/gui.py
+++ b/satisfactory_flow/gui.py
@@ -91,9 +91,14 @@ class App(tk.Tk):
         node_map: List[tuple[str, Node]] = []
         for idx, node in enumerate(self.nodes):
             cnt = max(1, int(round(node.count)))
+            if node.name.startswith("Source"):
+                cnt = 1
             for i in range(cnt):
                 node_id = f"{idx}_{i}"
-                label = f"{node.name}\n{node.clock:.1f}%"
+                if node.name.startswith("Source"):
+                    label = node.name
+                else:
+                    label = f"{node.name}\n{node.clock:.1f}%"
                 G.add_node(node_id, label=label)
                 node_map.append((node_id, node))
 


### PR DESCRIPTION
## Summary
- source nodes keep their clock speed hidden but maintain clock labels for all other nodes
- restore clock info on optimizer plan labels

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install networkx matplotlib requests`

------
https://chatgpt.com/codex/tasks/task_e_686f6471e31c832ba3445f94379178e9