### PR TITLE
Improve production summaries and byproduct handling

### DIFF
--- a/satisfactory_flow/console.py
+++ b/satisfactory_flow/console.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 
 from .models import Node
 from .auto import set_disabled_recipes
+from .summary import compute_summary
 
 WORKSPACE_FILE = "workspace.json"
 
@@ -55,7 +56,29 @@ class ConsoleApp:
             print("No nodes defined")
             return
         for idx, node in enumerate(self.nodes):
-            print(f"{idx}: {node.name} | Power {node.power_usage():.2f} MW")
+            outs = ", ".join(
+                f"{item} {amt:.1f}/\uBD84" for item, amt in node.scaled_outputs().items()
+            )
+            print(
+                f"{idx}: {node.name} | {outs} | Power {node.power_usage():.2f} MW"
+            )
+        summary = compute_summary(self.nodes)
+        if summary["sources"]:
+            src = ", ".join(
+                f"{k} {v:.1f}/\uBD84" for k, v in summary["sources"].items()
+            )
+            print(f"Sources: {src}")
+        if summary["byproducts"]:
+            bp = ", ".join(
+                f"{k} {v:.1f}/\uBD84" for k, v in summary["byproducts"].items()
+            )
+            print(f"Byproducts: {bp}")
+        if summary["products"]:
+            prod = ", ".join(
+                f"{k} {v:.1f}/\uBD84" for k, v in summary["products"].items()
+            )
+            print(f"Products: {prod}")
+        print(f"Power: {summary['power']:.2f} MW")
 
     def add_node(self) -> None:
         name = input("Name: ").strip()

--- a/satisfactory_flow/models.py
+++ b/satisfactory_flow/models.py
@@ -12,6 +12,7 @@ class Node:
     filled_slots: int = 0
     total_slots: int = 0
     count: float = 1.0
+    primary_output: str = ""
 
     def __post_init__(self) -> None:
         self.clock = round(max(0.0, min(self.clock, self.max_clock())), 4)
@@ -35,12 +36,21 @@ class Node:
     def production_factor(self) -> float:
         return (self.clock / 100.0) * self.power_multiplier() * self.count
 
+    def scaled_inputs(self) -> Dict[str, float]:
+        factor = (self.clock / 100.0) * self.power_multiplier()
+        return {k: v * factor for k, v in self.inputs.items()}
+
+    def scaled_outputs(self) -> Dict[str, float]:
+        factor = (self.clock / 100.0) * self.power_multiplier()
+        return {k: v * factor for k, v in self.outputs.items()}
+
     def to_dict(self) -> Dict:
         return {
             "name": self.name,
             "base_power": self.base_power,
             "inputs": self.inputs,
             "outputs": self.outputs,
+            "primary_output": self.primary_output,
             "clock": self.clock,
             "shards": self.shards,
             "filled_slots": self.filled_slots,
@@ -55,6 +65,7 @@ class Node:
             base_power=d.get("base_power", 0.0),
             inputs=d.get("inputs", {}),
             outputs=d.get("outputs", {}),
+            primary_output=d.get("primary_output", ""),
             clock=d.get("clock", 100.0),
             shards=d.get("shards", 0),
             filled_slots=d.get("filled_slots", 0),

--- a/satisfactory_flow/summary.py
+++ b/satisfactory_flow/summary.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Dict, List, Set
+
+from .models import Node
+
+
+def compute_summary(nodes: List[Node]) -> Dict[str, Dict[str, float] | float]:
+    """Return overall resource balance and power usage.
+
+    The result dictionary contains ``sources`` for required input items,
+    ``byproducts`` for excess outputs not targeted, ``products`` for net
+    production of targeted items and ``power`` for total power usage.
+    """
+    totals: Dict[str, float] = {}
+    targets: Set[str] = {
+        n.primary_output
+        for n in nodes
+        if n.primary_output and not n.name.startswith(("Source", "Loop"))
+    }
+
+    for n in nodes:
+        for item, amt in n.scaled_outputs().items():
+            totals[item] = totals.get(item, 0.0) + amt
+        for item, amt in n.scaled_inputs().items():
+            totals[item] = totals.get(item, 0.0) - amt
+
+    sources: Dict[str, float] = {}
+    byproducts: Dict[str, float] = {}
+    products: Dict[str, float] = {}
+    for item, val in totals.items():
+        if val < -1e-6:
+            sources[item] = -val
+        elif val > 1e-6:
+            if item in targets:
+                products[item] = val
+            else:
+                byproducts[item] = val
+
+    power = sum(n.power_usage() for n in nodes)
+    return {
+        "sources": sources,
+        "byproducts": byproducts,
+        "products": products,
+        "power": power,
+    }


### PR DESCRIPTION
## Summary
- track the primary output for each node and expose scaled input/output helpers
- include all recipe products when generating nodes
- compute overall resource balance and power usage
- display node production rates and totals in GUI and console
- show rates per minute on graph nodes

## Testing
- `python3 -m py_compile satisfactory_flow/*.py satisfactory_flow_gui.py scripts/optimize_production.py`
- `python3 satisfactory_flow_gui.py` *(fails: ModuleNotFoundError for networkx)*

------
https://chatgpt.com/codex/tasks/task_e_687076d580e4832b99b6239663fc8d84