### PR TITLE
Add throughput labels to graph edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Features
 - Save and load a workspace automatically (`workspace.json`).
 - Toggle unavailable alternate recipes via the **Recipes** button (saved in the workspace).
 - Visualize node connections with a simple graph using NetworkX and Matplotlib.
+- Edge labels show item throughput, e.g. `Iron Plate 20.0/min`.
 - Workspace is automatically saved when using **Show Graph**.
 - Shortcut **Ctrl+S** or the *Save* button to store the current workspace.
 

--- a/satisfactory_flow/gui.py
+++ b/satisfactory_flow/gui.py
@@ -108,12 +108,16 @@ class App(tk.Tk):
                 node_map.append((node_id, node))
 
         for src_id, src_node in node_map:
+            src_outs = src_node.scaled_outputs()
             for dst_id, dst_node in node_map:
                 if src_id == dst_id:
                     continue
+                dst_ins = dst_node.scaled_inputs()
                 for item in src_node.outputs:
                     if item in dst_node.inputs:
-                        G.add_edge(src_id, dst_id, label=item)
+                        rate = min(src_outs.get(item, 0.0), dst_ins.get(item, 0.0))
+                        label = f"{item} {rate:.1f}/min"
+                        G.add_edge(src_id, dst_id, label=label)
         return G
 
     def show_graph(self) -> None:


### PR DESCRIPTION
## Summary
- show flow rates on edges when building the graph
- document edge labels in README

## Testing
- `python3 -m py_compile satisfactory_flow/*.py satisfactory_flow_gui.py scripts/optimize_production.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68707cc629d0832ba669a80913f10e59